### PR TITLE
v1.0.0-beta5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,8 +68,12 @@ jobs:
       - name: Setup Environment Variables For Build Process
         id: current_version
         run: |
-          # Read Version from gradle.properties
-          echo "VERSION=`grep '^version=' gradle.properties | cut -d'=' -f2`" >> $GITHUB_ENV
+          TMPVERSION=$(grep '^version=' gradle.properties | cut -d'=' -f2)
+          if [[ "${{ github.ref }}" == "refs/heads/development" ]]; then
+            # Replace existing prerelease identifier with -snapshot or append -snapshot if none exists
+            TMPVERSION=$(echo $TMPVERSION | sed 's/-.*$//')-snapshot
+          fi
+          echo "VERSION=$TMPVERSION" >> $GITHUB_ENV
 
           # Branche
           echo "Github Ref is $GITHUB_REF"

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,14 @@ ext {
 	branch = System.getenv( 'BRANCH' ) ?: 'development'
 }
 
+if (branch == 'development') {
+    // If the branch is 'development', ensure the version ends with '-snapshot'
+    // This replaces any existing prerelease identifier with '-snapshot'
+    version = version.contains('-') ? version.replaceAll(/-.*/, '-snapshot') : "${version}-snapshot"
+	boxlangVersion = boxlangVersion.contains('-') ? boxlangVersion.replaceAll(/-.*/, '-snapshot') : "${boxlangVersion}-snapshot"
+}
+
+
 repositories {
     mavenLocal()
     mavenCentral()
@@ -32,18 +40,17 @@ repositories {
 dependencies {
 	// LOCAL DEVELOPMENT ONLY
 	// CHOOSE THE RIGHT LOCATION FOR YOUR LOCAL DEPENDENCIES
-    compileOnly files( '../boxlang/build/distributions/boxlang-' + boxlangVersion + '-all.jar' )
+    compileOnly files( '../boxlang/build/libs/boxlang-' + boxlangVersion + '-all.jar' )
 
 	// Production Dependency
-    compileOnly files( 'src/test/resources/libs/boxlang-' + boxlangVersion + '-all.jar' )
-	// https://mvnrepository.com/artifact/io.undertow/undertow-core/2.3.12.Final
-	compileOnly 'io.undertow:undertow-core:2.3.14.Final'
+   compileOnly files( 'src/test/resources/libs/boxlang-' + boxlangVersion + '-all.jar' )
 
 	// For HTML Parsing
 	implementation 'org.jsoup:jsoup:1.17.2'
 
     // Testing Dependencies
 	testImplementation files( 'src/test/resources/libs/boxlang-' + boxlangVersion + '-all.jar' )
+    testImplementation files( '../boxlang/build/libs/boxlang-' + boxlangVersion + '-all.jar' )
     testImplementation "org.junit.jupiter:junit-jupiter:5.+"
 	testImplementation "org.mockito:mockito-core:5.+"
 	testImplementation "com.google.truth:truth:1.+"

--- a/build.gradle
+++ b/build.gradle
@@ -76,12 +76,8 @@ compileTestJava {
 jar {
     archiveVersion =  "${version}"
  	manifest {
-	   	attributes 'Description': 'The BoxLang Web Support Package'
-		 if( branch == 'development' ){
-		   attributes 'Implementation-Version': "${version}-SNAPSHOT"
-	   } else {
-		   attributes 'Implementation-Version': "${version}+${buildID}"
-	   }
+	   attributes 'Description': 'The BoxLang Web Support Package'
+	   attributes 'Implementation-Version': "${version}+${buildID}"
 	   attributes 'Created-On': new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).format( new Date() )
 	   attributes 'Created-By': "Ortus Solutions, Corp"
     }
@@ -109,13 +105,7 @@ processResources {
 	// Replace @build.date@ with the current date in META-INF/version.properties file
 	filter( ReplaceTokens, tokens: [ 'build.date': new SimpleDateFormat( "yyyy-MM-dd HH:mm:ss" ).format( new Date() ) ] )
 	// Replace @build.version@ with the current version in META-INF/version.properties file
-	filter( ReplaceTokens, tokens: [ 'build.version': version ] )
-	// If we are in branch == development then update +build.number to -SNAPSHOT
-	if( branch == 'development' ){
-		filter( ReplaceTokens, tokens: [ 'build.number': "-SNAPSHOT" ] )
-	} else {
-		filter( ReplaceTokens, tokens: [ 'build.number': "+" + buildID ] )
-	}
+	filter( ReplaceTokens, tokens: [ 'build.version': version + "+" + buildID ] )
 }
 
 javadoc {

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta4] - 2024-07-05
+
 ## [1.0.0-beta3] - 2024-06-28
 
 ## [1.0.0-beta2] - 2024-06-21
@@ -17,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta3...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta4...HEAD
+
+[1.0.0-beta4]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta3...v1.0.0-beta4
 
 [1.0.0-beta3]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta2...v1.0.0-beta3
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Jun 28 10:50:58 UTC 2024
-boxlangVersion=1.0.0-beta4
+#Fri Jul 05 15:11:11 UTC 2024
+boxlangVersion=1.0.0-beta5
 jdkVersion=21
-version=1.0.0-beta4
+version=1.0.0-beta5
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -403,7 +403,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 
 	public IStruct getConfig() {
 		var config = super.getConfig();
-		config.getAsStruct( Key.runtime ).getAsStruct( Key.mappings ).put( "/", webRoot );
+		config.getAsStruct( Key.mappings ).put( "/", webRoot );
 		return config;
 	}
 

--- a/src/main/java/ortus/boxlang/web/scopes/RequestScope.java
+++ b/src/main/java/ortus/boxlang/web/scopes/RequestScope.java
@@ -19,6 +19,7 @@ package ortus.boxlang.web.scopes;
 
 import java.util.AbstractMap.SimpleEntry;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -135,7 +136,9 @@ public class RequestScope extends BaseScope {
 	 */
 	@Override
 	public Set<Key> keySet() {
-		var keys = wrapped.keySet();
+		// Create a new HashSet and add all keys from the wrapped map
+		Set<Key> keys = new HashSet<>( wrapped.keySet() );
+		// Add all keys from the exchange's request attribute map
 		keys.addAll( exchange.getRequestAttributeMap().keySet().stream().map( Key::of ).collect( Collectors.toSet() ) );
 		return keys;
 	}

--- a/src/main/resources/META-INF/boxlang-web-support/version.properties
+++ b/src/main/resources/META-INF/boxlang-web-support/version.properties
@@ -1,2 +1,2 @@
-version=@build.version@@build.number@
+version=@build.version@
 buildDate=@build.date@


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-beta5

### New Feature

[BL-319](https://ortussolutions.atlassian.net/browse/BL-319) Ability to call on \`navigate\( String... paths\)\` on the \`Configuration\` to create data navigators

[BL-320](https://ortussolutions.atlassian.net/browse/BL-320) Store the original last configuration seeded into the runtime as \`originalConfig\`

[BL-322](https://ortussolutions.atlassian.net/browse/BL-322) New StringBind\(\) bif and member function to bind a string with placeholder replacements using the \`$\{key\}\`

[BL-324](https://ortussolutions.atlassian.net/browse/BL-324) attempts now have a isNull\(\) to explicitly determine if the value is null

[BL-325](https://ortussolutions.atlassian.net/browse/BL-325) Allow Java methods to be referenced and passed around as a variable and invoked later like UDFs allow

[BL-326](https://ortussolutions.atlassian.net/browse/BL-326) New Application global defaults in the boxlang.json

[BL-330](https://ortussolutions.atlassian.net/browse/BL-330) new interception points when a session get's created and destroyed

[BL-338](https://ortussolutions.atlassian.net/browse/BL-338) Allow Java functional interfaces and SAMs to be wrapped and used as functions

[BL-339](https://ortussolutions.atlassian.net/browse/BL-339) All locations in the cache that returned optionals, now returns BoxLang Attempts

[BL-340](https://ortussolutions.atlassian.net/browse/BL-340) getAsAttempt\(\) on the IStruct default methods for convenience

[BL-341](https://ortussolutions.atlassian.net/browse/BL-341) BoxCacheProviders now have a localized interceptor pool alongside the runtime pool

[BL-342](https://ortussolutions.atlassian.net/browse/BL-342) Sessions are now monitored by cache interceptors to detect removals so as to shutdown the sessions before removal

[BL-343](https://ortussolutions.atlassian.net/browse/BL-343) application, session, request timeouts in the boxlang.json are now string timespans

[BL-344](https://ortussolutions.atlassian.net/browse/BL-344) App Timeouts are now working

### Improvement

[BL-209](https://ortussolutions.atlassian.net/browse/BL-209) Combine config settings into a single struct

[BL-318](https://ortussolutions.atlassian.net/browse/BL-318) Allow optional attribute delimiters in ACF tag-in-script syntax

[BL-321](https://ortussolutions.atlassian.net/browse/BL-321) Refactor dump loading of CSS to use caching again

[BL-323](https://ortussolutions.atlassian.net/browse/BL-323) Refactor page pool to be per-mapping

[BL-329](https://ortussolutions.atlassian.net/browse/BL-329) jsessionID is the internal standard for boxlang sessions, move to this instead of cfid

[BL-332](https://ortussolutions.atlassian.net/browse/BL-332) getOrSet\(\) in the cache should return the object not an optional

### Bug

[BL-164](https://ortussolutions.atlassian.net/browse/BL-164) BL Compat module should coerce null values to empty string

[BL-252](https://ortussolutions.atlassian.net/browse/BL-252) MSSQL DROP TABLE throws 'The statement must be executed before any results can be obtained'

[BL-306](https://ortussolutions.atlassian.net/browse/BL-306) Adobe Compatibility: Missing support for new java\(\) and new component\(\)

[BL-308](https://ortussolutions.atlassian.net/browse/BL-308) cfinvoke does not support params as attribute-value pairs

[BL-316](https://ortussolutions.atlassian.net/browse/BL-316) If the global runtime \`javaLibraryPaths\` is already a jar/class location, then use it, else it breaks

[BL-317](https://ortussolutions.atlassian.net/browse/BL-317) allow "var" before CF catch variable in script

[BL-331](https://ortussolutions.atlassian.net/browse/BL-331) ResetSession on the scripting request context was invalidating the new session instead of the old session

[BL-333](https://ortussolutions.atlassian.net/browse/BL-333) Session creation if the default timeout is not a duration, it should treat it as seconds, not milliseconds

[BL-334](https://ortussolutions.atlassian.net/browse/BL-334) Session object was not serializable

[BL-335](https://ortussolutions.atlassian.net/browse/BL-335) Cache was evicting items without reaping

[BL-336](https://ortussolutions.atlassian.net/browse/BL-336) DateTime toString\(\) not accounting for formatter being null

[BL-337](https://ortussolutions.atlassian.net/browse/BL-337) sessionRotate\(\) not copying over old keys due to nullification of keys when invalidating the old session

[BL-319]: https://ortussolutions.atlassian.net/browse/BL-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-320]: https://ortussolutions.atlassian.net/browse/BL-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-322]: https://ortussolutions.atlassian.net/browse/BL-322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-324]: https://ortussolutions.atlassian.net/browse/BL-324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-325]: https://ortussolutions.atlassian.net/browse/BL-325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-326]: https://ortussolutions.atlassian.net/browse/BL-326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-330]: https://ortussolutions.atlassian.net/browse/BL-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-338]: https://ortussolutions.atlassian.net/browse/BL-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ