### PR TITLE
v1.0.0-Beta6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta5] - 2024-07-12
+
 ## [1.0.0-beta4] - 2024-07-05
 
 ## [1.0.0-beta3] - 2024-06-28
@@ -19,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta4...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta5...HEAD
+
+[1.0.0-beta5]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta4...v1.0.0-beta5
 
 [1.0.0-beta4]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta3...v1.0.0-beta4
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Jul 05 15:11:11 UTC 2024
-boxlangVersion=1.0.0-beta5
+#Fri Jul 12 11:09:58 UTC 2024
+boxlangVersion=1.0.0-beta6
 jdkVersion=21
-version=1.0.0-beta5
+version=1.0.0-beta6
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -403,7 +403,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 
 	public IStruct getConfig() {
 		var config = super.getConfig();
-		config.getAsStruct( Key.runtime ).getAsStruct( Key.mappings ).put( "/", webRoot );
+		config.getAsStruct( Key.mappings ).put( "/", webRoot );
 		return config;
 	}
 

--- a/src/main/java/ortus/boxlang/web/util/KeyDictionary.java
+++ b/src/main/java/ortus/boxlang/web/util/KeyDictionary.java
@@ -25,5 +25,8 @@ public class KeyDictionary {
 	public static final Key	htmlHead			= Key.of( "htmlHead" );
 	public static final Key	htmlFooter			= Key.of( "htmlFooter" );
 	public static final Key	onRequestEnd		= Key.of( "onRequestEnd" );
+	public static final Key	fileName			= Key.of( "fileName" );
+	public static final Key	disposition			= Key.of( "disposition" );
+	public static final Key	success				= Key.of( "success" );
 
 }


### PR DESCRIPTION
BoxLang Betas are released weekly.  This is our fifth beta marker.  Here are the release notes.
New Feature
[BL-346](https://ortussolutions.atlassian.net/browse/BL-346) DynamicObject equals() hashCode() to allow for dynamic checking
[BL-157](https://ortussolutions.atlassian.net/browse/BL-157) Implement nested transactions
[BL-348](https://ortussolutions.atlassian.net/browse/BL-348) queryReverse() finalized
[BL-349](https://ortussolutions.atlassian.net/browse/BL-349) Allow servlet to expand paths so CommandBox web aliases or ModCFML web dirs can be used CF
[BL-350](https://ortussolutions.atlassian.net/browse/BL-350) Allow static functional access to BIFs
[BL-351](https://ortussolutions.atlassian.net/browse/BL-351) Allow Functional binding to members.
[BL-352](https://ortussolutions.atlassian.net/browse/BL-352) arrayRange() BIF to create arrays with a specific range of values.
[BL-353](https://ortussolutions.atlassian.net/browse/BL-353) threadTerminate() finalized
[BL-354](https://ortussolutions.atlassian.net/browse/BL-354) threadJoin() BIF Finalized
[BL-355](https://ortussolutions.atlassian.net/browse/BL-355) queryInsertAt() BIF finalized
[BL-356](https://ortussolutions.atlassian.net/browse/BL-356) QueryRowSwap() bif finalized
[BL-358](https://ortussolutions.atlassian.net/browse/BL-358) runAsync() completed but based on the powerful new BoxFuture -> CompletableFuture
[BL-359](https://ortussolutions.atlassian.net/browse/BL-359) BIF Collection for managing and interacting with async service executors: list, get, has, new, shutdown
[BL-360](https://ortussolutions.atlassian.net/browse/BL-360) Configuration now supports executors registration for global usage
[BL-124](https://ortussolutions.atlassian.net/browse/BL-124) Implement primary/foreign key columns in dbInfo
[BL-255](https://ortussolutions.atlassian.net/browse/BL-255) Implement QueryMeta class for $.bx.meta or $.bx.getMeta() debugging support
Improvements
[BL-357](https://ortussolutions.atlassian.net/browse/BL-357) "Fix" return types of BIFs that return "true" for no real reason
[BL-366](https://ortussolutions.atlassian.net/browse/BL-366) Provide Java FI typing on all higher order BIFs
[BL-371](https://ortussolutions.atlassian.net/browse/BL-371) make name un-required in application component
Bugs
[BL-364](https://ortussolutions.atlassian.net/browse/BL-364) Overridden getter in parent class not being used
[BL-370](https://ortussolutions.atlassian.net/browse/BL-370) List and Delmiter Args not correct in ListReduce callback
[BL-365](https://ortussolutions.atlassian.net/browse/BL-365) Throwable Dump table is not styled

[BL-346]: https://ortussolutions.atlassian.net/browse/BL-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-157]: https://ortussolutions.atlassian.net/browse/BL-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-348]: https://ortussolutions.atlassian.net/browse/BL-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-349]: https://ortussolutions.atlassian.net/browse/BL-349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-350]: https://ortussolutions.atlassian.net/browse/BL-350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-351]: https://ortussolutions.atlassian.net/browse/BL-351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-352]: https://ortussolutions.atlassian.net/browse/BL-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-353]: https://ortussolutions.atlassian.net/browse/BL-353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-354]: https://ortussolutions.atlassian.net/browse/BL-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-355]: https://ortussolutions.atlassian.net/browse/BL-355?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ