### PR TITLE
v1.0.0-Beta9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,5 @@ build/**
 ### BOXLANG ###
 grapher/**
 /libs/
+/workbench/*
 src/test/resources/libs/

--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,5 @@ build/**
 grapher/**
 /libs/
 /workbench/*
+src/test/resources/tmp/
 src/test/resources/libs/

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta8] - 2024-08-02
+
 ## [1.0.0-beta7] - 2024-07-26
 
 ## [1.0.0-beta6] - 2024-07-19
@@ -25,7 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta7...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta8...HEAD
+
+[1.0.0-beta8]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta7...v1.0.0-beta8
 
 [1.0.0-beta7]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta6...v1.0.0-beta7
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Jul 26 19:26:11 UTC 2024
-boxlangVersion=1.0.0-beta8
+#Fri Aug 02 16:05:05 UTC 2024
+boxlangVersion=1.0.0-beta9
 jdkVersion=21
-version=1.0.0-beta8
+version=1.0.0-beta9
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/bifs/FileUpload.java
+++ b/src/main/java/ortus/boxlang/web/bifs/FileUpload.java
@@ -1,0 +1,252 @@
+
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.web.bifs;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import ortus.boxlang.compiler.parser.Parser;
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.DateTime;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
+import ortus.boxlang.runtime.types.exceptions.BoxIOException;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.types.util.BLCollector;
+import ortus.boxlang.runtime.types.util.ListUtil;
+import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.runtime.validation.Validator;
+import ortus.boxlang.web.context.WebRequestBoxContext;
+import ortus.boxlang.web.exchange.IBoxHTTPExchange;
+import ortus.boxlang.web.util.KeyDictionary;
+
+@BoxBIF
+@BoxBIF( alias = "FileUploadAll" )
+
+public class FileUpload extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public FileUpload() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( true, "string", Key.destination ),
+		    new Argument( false, "string", Key.accept ),
+		    new Argument( false, "string", Key.nameconflict, "error", Set.of( Validator.valueOneOf( "error", "skip", "overwrite", "makeunique" ) ) ),
+		    new Argument( false, "string", KeyDictionary.allowedExtensions ),
+		    new Argument( false, "string", Key.filefield ),
+		    new Argument( false, "string", Key.strict )
+		};
+	}
+
+	/**
+	 * Describe what the invocation of your bif function does
+	 *
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 *
+	 * @argument.foo Describe any expected arguments
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		Key						action			= Key.of( arguments.getAsString( Key.action ) );
+		WebRequestBoxContext	requestContext	= context.getParentOfType( WebRequestBoxContext.class );
+		String					variable		= arguments.getAsString( Key.variable );
+		Key						bifMethodKey	= arguments.getAsKey( BIF.__functionName );
+
+		if ( variable == null && arguments.containsKey( Key.result ) ) {
+			variable = arguments.getAsString( Key.result );
+		}
+
+		if ( requestContext == null ) {
+			throw new BoxRuntimeException(
+			    String.format( "The specified file action [%s] is is not valid in a non-web runtime", action.getName() ) );
+		}
+
+		IBoxHTTPExchange				exchange	= requestContext.getHTTPExchange();
+
+		IBoxHTTPExchange.FileUpload[]	uploads		= exchange.getUploadData();
+
+		if ( uploads == null ) {
+			throw new BoxRuntimeException( "No file uploads were found in the request" );
+		} else if ( bifMethodKey.equals( KeyDictionary.fileUpload ) ) {
+			Key							fieldKey	= Key.of( arguments.getAsString( Key.filefield ) );
+			IBoxHTTPExchange.FileUpload	upload		= null;
+			if ( fieldKey == null ) {
+				upload = uploads[ 0 ];
+			} else {
+				upload = Stream.of( uploads ).filter( u -> u.formFieldName().equals( fieldKey ) ).findFirst().orElse( null );
+				if ( upload == null ) {
+					throw new BoxRuntimeException( "The specified file field [" + fieldKey.getName() + "] was not found in the upload data" );
+				}
+			}
+
+			return uploadFile( upload, arguments, context );
+
+		} else {
+			return Stream.of( uploads ).map( upload -> uploadFile( upload, arguments, context ) ).collect( BLCollector.toArray() );
+		}
+	}
+
+	private IStruct uploadFile( IBoxHTTPExchange.FileUpload upload, IStruct arguments, IBoxContext context ) {
+		String	destination		= arguments.getAsString( Key.destination );
+		Path	destinationPath	= null;
+		Boolean	createPath		= false;
+
+		if ( !Path.of( destination ).isAbsolute() ) {
+			destinationPath	= Path.of( FileSystemUtil.getTempDirectory(), destination );
+			createPath		= true;
+		} else {
+			destinationPath = FileSystemUtil.expandPath( context, destination ).absolutePath();
+		}
+
+		if ( !Files.isDirectory( destinationPath ) ) {
+			throw new BoxRuntimeException( "The specified destination path [" + destination + "] is not a directory" );
+		}
+
+		if ( !Files.exists( destinationPath ) && createPath ) {
+			try {
+				Files.createDirectories( destinationPath );
+			} catch ( IOException e ) {
+				throw new BoxIOException( "The specified destination path [" + destination + "] could not be created", e );
+			}
+		}
+		if ( !Files.exists( destinationPath ) ) {
+			throw new BoxRuntimeException( "The specified destination path [" + destination + "] does not exist" );
+		}
+
+		String	fileName		= upload.originalFileName();
+		String	extension		= Parser.getFileExtension( fileName ).get();
+		Path	filePath		= destinationPath.resolve( fileName );
+		String	nameConflict	= arguments.getAsString( Key.nameconflict );
+
+		IStruct	uploadRecord	= newUploadRecord();
+		uploadRecord.put( KeyDictionary.clientDirectory, destinationPath.toString() );
+		uploadRecord.put( KeyDictionary.clientFile, filePath.toString() );
+		uploadRecord.put( KeyDictionary.clientFileExt, extension );
+		uploadRecord.put( KeyDictionary.clientFileName, fileName );
+		uploadRecord.put( KeyDictionary.attemptedServerFile, filePath.toString() );
+		try {
+			uploadRecord.put( KeyDictionary.fileSize, Files.size( upload.tmpPath() ) );
+		} catch ( IOException e ) {
+			throw new BoxIOException( "The size of the uploaded file [" + fileName + "] could not be determined", e );
+		}
+
+		DateTime operationDate = new DateTime();
+
+		uploadRecord.put( KeyDictionary.timeCreated, operationDate );
+
+		if ( Files.exists( filePath ) ) {
+			uploadRecord.put( KeyDictionary.fileExisted, true );
+			try {
+				uploadRecord.put( KeyDictionary.timeCreated, new DateTime( ( ( FileTime ) Files.getAttribute( filePath, "creationTime" ) ).toInstant() ) );
+			} catch ( IOException e ) {
+				e.printStackTrace();
+			}
+			try {
+				uploadRecord.put( KeyDictionary.oldFileSize, Files.size( filePath ) );
+			} catch ( IOException e ) {
+				throw new BoxIOException( "The size of the original file [" + fileName + "] could not be determined", e );
+			}
+			switch ( nameConflict ) {
+				case "error" :
+					throw new BoxRuntimeException( "The file [" + fileName + "] already exists in the destination path [" + destination + "]" );
+				case "skip" :
+					return uploadRecord;
+				case "overwrite" :
+					try {
+						Files.delete( filePath );
+						uploadRecord.put( KeyDictionary.fileWasOverwritten, true );
+					} catch ( IOException e ) {
+						throw new BoxIOException( "The file [" + fileName + "] could not be deleted from the destination path [" + destination + "]", e );
+					}
+					break;
+				case "makeunique" :
+					String baseName = fileName.substring( 0, fileName.length() - extension.length() - 1 );
+					fileName = baseName + "_" + System.currentTimeMillis() + "." + extension;
+					filePath = destinationPath.resolve( fileName );
+					uploadRecord.put( KeyDictionary.fileWasRenamed, true );
+					break;
+			}
+		}
+
+		try {
+			Files.move( upload.tmpPath(), filePath );
+			String mimeType = Files.probeContentType( filePath );
+			if ( mimeType == null ) {
+				mimeType = "application/octet-stream";
+			}
+			uploadRecord.put( KeyDictionary.contentType, mimeType );
+			uploadRecord.put( KeyDictionary.contentSubType, ListUtil.asList( mimeType, "/" ).get( 1 ) );
+			uploadRecord.put( KeyDictionary.timeLastModified, operationDate );
+			uploadRecord.put( KeyDictionary.dateLastAccessed, operationDate );
+			uploadRecord.put( KeyDictionary.serverFile, filePath.toString() );
+			uploadRecord.put( KeyDictionary.serverFileExt, extension );
+			uploadRecord.put( KeyDictionary.serverFileName, fileName );
+			uploadRecord.put( KeyDictionary.serverDirectory, filePath.getParent().toString() );
+			uploadRecord.put( KeyDictionary.fileSize, Files.size( filePath ) );
+			uploadRecord.put( KeyDictionary.fileWasSaved, true );
+		} catch ( IOException e ) {
+			throw new BoxIOException( "The uploaded file [" + fileName + "] could not be saved to the destination path [" + destination + "]", e );
+		}
+
+		return uploadRecord;
+	}
+
+	/**
+	 * Returns an empty struct containing the keys used to track file uploads
+	 *
+	 * @return
+	 */
+	private IStruct newUploadRecord() {
+		return Struct.of(
+		    KeyDictionary.attemptedServerFile, null, // Initial name ColdFusion used when attempting to save a file
+		    KeyDictionary.clientDirectory, null, // Directory location of the file uploaded from the client's system
+		    KeyDictionary.clientFile, null, // Name of the file uploaded from the client's system
+		    KeyDictionary.clientFileExt, null, // Extension of the uploaded file on the client system (without a period)
+		    KeyDictionary.clientFileName, null, // Name of the uploaded file on the client system (without an extension)
+		    KeyDictionary.contentSubType, null, // MIME content subtype of the saved file
+		    KeyDictionary.contentType, null, // MIME content type of the saved file
+		    KeyDictionary.dateLastAccessed, null, // Date and time the uploaded file was last accessed
+		    KeyDictionary.fileExisted, false, // Whether the file existed with the same path (yes or no)
+		    KeyDictionary.fileSize, null, // Size of the uploaded file in bytes
+		    KeyDictionary.fileWasAppended, false, // Whether ColdFusion appended uploaded file to a file (yes or no)
+		    KeyDictionary.fileWasOverwritten, false, // Whether ColdFusion overwrote a file (yes or no)
+		    KeyDictionary.fileWasRenamed, false, // Whether uploaded file renamed to avoid a name conflict (yes or no)
+		    KeyDictionary.fileWasSaved, false, // Whether ColdFusion saves a file (yes or no)
+		    KeyDictionary.oldFileSize, null, // Size of a file that was overwritten in the file upload operation
+		    KeyDictionary.serverDirectory, null, // Directory of the file saved on the server
+		    KeyDictionary.serverFile, null, // Filename of the file saved on the server
+		    KeyDictionary.serverFileExt, null, // Extension of the uploaded file on the server (without a period)
+		    KeyDictionary.serverFileName, null, // Name of the uploaded file on the server (without an extension)
+		    KeyDictionary.timeCreated, null, // Time the uploaded file was created
+		    KeyDictionary.timeLastModified, null // Date and time of the last modification to the uploaded file
+		);
+	}
+
+}

--- a/src/main/java/ortus/boxlang/web/bifs/FileUpload.java
+++ b/src/main/java/ortus/boxlang/web/bifs/FileUpload.java
@@ -70,12 +70,22 @@ public class FileUpload extends BIF {
 	}
 
 	/**
-	 * Describe what the invocation of your bif function does
+	 * Processes file uploads from the request
 	 *
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.foo Describe any expected arguments
+	 * @argument.destination The destination directory for the uploaded files.
+	 * 
+	 * @argument.accept The accepted MIME types for the uploaded files.
+	 * 
+	 * @argument.nameconflict The action to take when a file with the same name already exists in the destination directory.
+	 * 
+	 * @argument.allowedExtensions The allowed file extensions for the uploaded files.
+	 * 
+	 * @argument.filefield The name of the file field to process.
+	 * 
+	 * @argument.strict Whether to strictly enforce the system specified upload security settings.
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		WebRequestBoxContext			requestContext	= context.getParentOfType( WebRequestBoxContext.class );

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -320,7 +320,6 @@ public class WebRequestBoxContext extends RequestBoxContext {
 		return getScope( name );
 	}
 
-	@Override
 	public void registerUDF( UDF udf, boolean override ) {
 		if ( override || !variablesScope.containsKey( udf.getName() ) ) {
 			variablesScope.put( udf.getName(), udf );
@@ -376,7 +375,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 
 	/**
 	 * Get the HTTP exchange
-	 * 
+	 *
 	 * @return The HTTP exchange
 	 */
 	public IBoxHTTPExchange getHTTPExchange() {
@@ -411,7 +410,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 
 	/**
 	 * Get the web root for this request
-	 * 
+	 *
 	 * @return The web root
 	 */
 	public String getWebRoot() {

--- a/src/main/java/ortus/boxlang/web/interceptors/WebRequest.java
+++ b/src/main/java/ortus/boxlang/web/interceptors/WebRequest.java
@@ -165,7 +165,7 @@ public class WebRequest extends BaseInterceptor {
 			IStruct				attributes	= data.getAsStruct( Key.attributes );
 			ComponentBody		body		= ( ComponentBody ) data.get( Key.body );
 			Cache.CacheAction	cacheAction	= Cache.CacheAction.fromString( attributes.getAsString( Key.action ) );
-			Double				timespan	= DoubleCaster.cast( attributes.get( Key.timespan ) );
+			Double				timespan	= attributes.getAsDouble( Key.timespan );
 
 			if ( context.getParentOfType( WebRequestBoxContext.class ) == null ) {
 				throw new BoxRuntimeException(

--- a/src/main/java/ortus/boxlang/web/interceptors/WebRequest.java
+++ b/src/main/java/ortus/boxlang/web/interceptors/WebRequest.java
@@ -149,7 +149,7 @@ public class WebRequest {
 			IStruct				attributes	= data.getAsStruct( Key.attributes );
 			ComponentBody		body		= ( ComponentBody ) data.get( Key.body );
 			Cache.CacheAction	cacheAction	= Cache.CacheAction.fromString( attributes.getAsString( Key.action ) );
-			Double				timespan	= attributes.getAsDouble( Key.timespan );
+			Double				timespan	= DoubleCaster.cast( attributes.get( Key.timespan ) );
 
 			if ( context.getParentOfType( WebRequestBoxContext.class ) == null ) {
 				throw new BoxRuntimeException(

--- a/src/main/java/ortus/boxlang/web/interceptors/WebRequest.java
+++ b/src/main/java/ortus/boxlang/web/interceptors/WebRequest.java
@@ -28,7 +28,7 @@ import ortus.boxlang.runtime.context.RequestBoxContext;
 import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.dynamic.casters.DoubleCaster;
 import ortus.boxlang.runtime.dynamic.casters.StringCaster;
-import ortus.boxlang.runtime.dynamic.casters.StructCaster;
+import ortus.boxlang.runtime.events.BaseInterceptor;
 import ortus.boxlang.runtime.events.InterceptionPoint;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.services.ComponentService;
@@ -43,7 +43,7 @@ import ortus.boxlang.web.util.KeyDictionary;
 /**
  * Web request based interceptions
  */
-public class WebRequest {
+public class WebRequest extends BaseInterceptor {
 
 	/**
 	 * The runtime instance
@@ -144,9 +144,7 @@ public class WebRequest {
 
 		data.put(
 		    Key.response,
-		    StructCaster.cast(
-		        runtime.getFunctionService().getGlobalFunction( BIFMethod ).invoke( context, attributes, false, BIFMethod )
-		    )
+		    runtime.getFunctionService().getGlobalFunction( BIFMethod ).invoke( context, attributes, false, BIFMethod )
 		);
 
 	}

--- a/src/main/java/ortus/boxlang/web/util/KeyDictionary.java
+++ b/src/main/java/ortus/boxlang/web/util/KeyDictionary.java
@@ -29,4 +29,32 @@ public class KeyDictionary {
 	public static final Key	disposition			= Key.of( "disposition" );
 	public static final Key	success				= Key.of( "success" );
 
+	// File Upload keys
+	public static final Key	upload				= Key.of( "upload" );
+	public static final Key	uploadAll			= Key.of( "uploadAll" );
+	public static final Key	fileUpload			= Key.of( "fileUpload" );
+	public static final Key	fileUploadAll		= Key.of( "fileUploadAll" );
+	public static final Key	allowedExtensions	= Key.of( "allowedExtensions" );
+	public static final Key	attemptedServerFile	= Key.of( "attemptedServerFile" );
+	public static final Key	clientDirectory		= Key.of( "clientDirectory" );
+	public static final Key	clientFile			= Key.of( "clientFile" );
+	public static final Key	clientFileExt		= Key.of( "clientFileExt" );
+	public static final Key	clientFileName		= Key.of( "clientFileName" );
+	public static final Key	contentSubType		= Key.of( "contentSubType" );
+	public static final Key	contentType			= Key.of( "contentType" );
+	public static final Key	dateLastAccessed	= Key.of( "dateLastAccessed" );
+	public static final Key	fileExisted			= Key.of( "fileExisted" );
+	public static final Key	fileSize			= Key.of( "fileSize" );
+	public static final Key	fileWasAppended		= Key.of( "fileWasAppended" );
+	public static final Key	fileWasOverwritten	= Key.of( "fileWasOverwritten" );
+	public static final Key	fileWasRenamed		= Key.of( "fileWasRenamed" );
+	public static final Key	fileWasSaved		= Key.of( "fileWasSaved" );
+	public static final Key	oldFileSize			= Key.of( "oldFileSize" );
+	public static final Key	serverDirectory		= Key.of( "serverDirectory" );
+	public static final Key	serverFile			= Key.of( "serverFile" );
+	public static final Key	serverFileExt		= Key.of( "serverFileExt" );
+	public static final Key	serverFileName		= Key.of( "serverFileName" );
+	public static final Key	timeCreated			= Key.of( "timeCreated" );
+	public static final Key	timeLastModified	= Key.of( "timeLastModified" );
+
 }

--- a/src/test/java/ortus/boxlang/web/bifs/FileUploadTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/FileUploadTest.java
@@ -1,0 +1,145 @@
+
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.web.bifs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.exceptions.BoxIOException;
+import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.web.context.WebRequestBoxContext;
+import ortus.boxlang.web.exchange.IBoxHTTPExchange;
+import ortus.boxlang.web.util.KeyDictionary;
+
+public class FileUploadTest {
+
+	static BoxRuntime			runtime;
+	IBoxContext					context;
+	IScope						variables;
+	// Web Assets for mocking
+	public WebRequestBoxContext	webContext;
+	public IBoxHTTPExchange		mockExchange;
+	public static final String	TEST_WEBROOT	= Path.of( "src/test/resources/webroot" ).toAbsolutePath().toString();
+	// Test Constants
+	static Key					result			= new Key( "result" );
+	static String				testURLImage	= "https://ortus-public.s3.amazonaws.com/logos/ortus-medium.jpg";
+	static String				tmpDirectory	= "src/test/resources/tmp/FileUpload";
+	static String				testUpload		= tmpDirectory + "/test.jpg";
+
+	static String[]				testFields		= new String[] { "file1", "file2", "file3" };
+
+	@BeforeAll
+	public static void setUp() throws MalformedURLException, IOException {
+		runtime = BoxRuntime.getInstance( true );
+		System.out.println( "Temp Directory Exists " + FileSystemUtil.exists( tmpDirectory ) );
+		if ( !FileSystemUtil.exists( tmpDirectory ) ) {
+			FileSystemUtil.createDirectory( tmpDirectory, true, null );
+		}
+		if ( !FileSystemUtil.exists( testUpload ) ) {
+			BufferedInputStream urlStream = new BufferedInputStream( URI.create( testURLImage ).toURL().openStream() );
+			FileSystemUtil.write( testUpload, urlStream.readAllBytes(), true );
+		}
+	}
+
+	@AfterAll
+	public static void teardown() {
+		if ( FileSystemUtil.exists( tmpDirectory ) ) {
+			FileSystemUtil.deleteDirectory( tmpDirectory, true );
+		}
+	}
+
+	@BeforeEach
+	public void setupEach() throws IOException {
+		if ( !FileSystemUtil.exists( testUpload ) ) {
+			BufferedInputStream urlStream = new BufferedInputStream( URI.create( testURLImage ).toURL().openStream() );
+			FileSystemUtil.write( testUpload, urlStream.readAllBytes(), true );
+		}
+
+		// Mock a connection
+		mockExchange = Mockito.mock( IBoxHTTPExchange.class );
+		List<ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload> fileUploads = new ArrayList<ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload>();
+
+		Stream.of( testFields ).forEach( field -> {
+			Path fieldFile = Path.of( tmpDirectory, field + ".jpg" );
+			try {
+				Files.copy( Path.of( testUpload ), fieldFile, StandardCopyOption.REPLACE_EXISTING );
+			} catch ( IOException e ) {
+				throw new BoxIOException( e );
+			}
+			fileUploads.add( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload( Key.of( field ), fieldFile, fieldFile.getFileName().toString() ) );
+		} );
+
+		when( mockExchange.getUploadData() ).thenReturn( ( ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload[] ) fileUploads.toArray() );
+
+		// Create the mock contexts
+		context		= new ScriptingRequestBoxContext( runtime.getRuntimeContext() );
+		webContext	= new WebRequestBoxContext( context, mockExchange, TEST_WEBROOT );
+		variables	= webContext.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It tests the BIF FileUpload" )
+	@Test
+	public void testBif() {
+		variables.put( Key.of( "filefield" ), testFields[ 0 ] );
+		variables.put( Key.directory, Path.of( tmpDirectory ).toAbsolutePath().toString() );
+		runtime.executeSource(
+		    """
+		    result = FileUpload(
+		    	filefield = filefield,
+		    	directory = directory
+		    );
+		    """,
+		    context );
+
+		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
+
+		assertThat( variables.getAsStruct( result ).getAsString( KeyDictionary.serverFile ) )
+		    .isEqualTo( Path.of( tmpDirectory, testFields[ 0 ] + ".jpg" ).toAbsolutePath().toString() );
+
+		// Statement execution only and return the result:
+		// assertThat( ( Boolean ) instance.executeStatement( "FileUpload( ' + "foo" +' )" ) ).isTrue();
+
+	}
+
+}

--- a/src/test/java/ortus/boxlang/web/bifs/FileUploadTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/FileUploadTest.java
@@ -41,7 +41,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.dynamic.casters.StructCaster;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Array;
@@ -54,18 +53,17 @@ import ortus.boxlang.web.util.KeyDictionary;
 public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 
 	ArrayList<ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload>	mockUploads;
-	public static final String											TEST_WEBROOT	= Path.of( "src/test/resources/webroot" ).toAbsolutePath().toString();
+	public final String													TEST_WEBROOT	= Path.of( "src/test/resources/webroot" ).toAbsolutePath().toString();
 	// Test Constants
-	static Key															result			= new Key( "result" );
-	static String														testURLImage	= "https://ortus-public.s3.amazonaws.com/logos/ortus-medium.jpg";
-	static String														tmpDirectory	= "src/test/resources/tmp/FileUpload";
-	static String														testUpload		= tmpDirectory + "/test.jpg";
+	final Key															result			= new Key( "result" );
+	final String														testURLImage	= "https://ortus-public.s3.amazonaws.com/logos/ortus-medium.jpg";
+	final String														tmpDirectory	= "src/test/resources/tmp/FileUpload";
+	final String														testUpload		= tmpDirectory + "/test.jpg";
 
-	static String[]														testFields		= new String[] { "file1", "file2", "file3" };
+	final String[]														testFields		= new String[] { "file1", "file2", "file3" };
 
 	@BeforeAll
-	public static void setUpTempFileSystem() throws MalformedURLException, IOException {
-		runtime = BoxRuntime.getInstance( true );
+	public void setUpTempFileSystem() throws MalformedURLException, IOException {
 		if ( !FileSystemUtil.exists( tmpDirectory ) ) {
 			FileSystemUtil.createDirectory( tmpDirectory, true, null );
 		}
@@ -76,7 +74,7 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 	}
 
 	@AfterAll
-	public static void teardown() {
+	public void teardown() {
 		if ( FileSystemUtil.exists( tmpDirectory ) ) {
 			FileSystemUtil.deleteDirectory( tmpDirectory, true );
 		}

--- a/src/test/java/ortus/boxlang/web/bifs/GetPageContextTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/GetPageContextTest.java
@@ -25,7 +25,7 @@ public class GetPageContextTest extends BaseWebTest {
 		    """
 		    	result = getPageContext();
 		    """,
-		    webContext );
+		    context );
 		// @formatter:on
 
 		// Check the result

--- a/src/test/java/ortus/boxlang/web/bifs/GetPageContextTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/GetPageContextTest.java
@@ -29,8 +29,7 @@ public class GetPageContextTest extends BaseWebTest {
 		// @formatter:on
 
 		// Check the result
-		var result = variables.get( BaseWebTest.result );
-		assertThat( result ).isInstanceOf( GetPageContext.PageContext.class );
+		assertThat( variables.get( result ) ).isInstanceOf( GetPageContext.PageContext.class );
 	}
 
 }

--- a/src/test/java/ortus/boxlang/web/components/FileTest.java
+++ b/src/test/java/ortus/boxlang/web/components/FileTest.java
@@ -1,0 +1,151 @@
+package ortus.boxlang.web.components;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.compiler.parser.BoxSourceType;
+import ortus.boxlang.runtime.dynamic.casters.StructCaster;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Array;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.exceptions.BoxIOException;
+import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.web.util.KeyDictionary;
+
+public class FileTest extends ortus.boxlang.web.util.BaseWebTest {
+
+	ArrayList<ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload>	mockUploads		= new ArrayList<ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload>();;
+	public final String													TEST_WEBROOT	= Path.of( "src/test/resources/webroot" ).toAbsolutePath().toString();
+	// Test Constants
+	Key																	result			= new Key( "result" );
+	String																testURLImage	= "https://ortus-public.s3.amazonaws.com/logos/ortus-medium.jpg";
+	String																tmpDirectory	= "src/test/resources/tmp/FileComponentTests";
+	String																testUpload		= tmpDirectory + "/test.jpg";
+
+	String[]															testFields		= new String[] { "file1", "file2", "file3" };
+
+	@BeforeAll
+	public void setUpTempFileSystem() throws MalformedURLException, IOException {
+		if ( !FileSystemUtil.exists( tmpDirectory ) ) {
+			FileSystemUtil.createDirectory( tmpDirectory, true, null );
+		}
+		if ( !FileSystemUtil.exists( testUpload ) ) {
+			BufferedInputStream urlStream = new BufferedInputStream( URI.create( testURLImage ).toURL().openStream() );
+			FileSystemUtil.write( testUpload, urlStream.readAllBytes(), true );
+		}
+	}
+
+	@AfterAll
+	public void teardown() {
+		if ( FileSystemUtil.exists( tmpDirectory ) ) {
+			FileSystemUtil.deleteDirectory( tmpDirectory, true );
+		}
+	}
+
+	@BeforeEach
+	public void setupUploads() throws IOException, URISyntaxException {
+		System.out.println( "Setting up uploads" );
+		if ( !FileSystemUtil.exists( testUpload ) ) {
+			BufferedInputStream urlStream = new BufferedInputStream( URI.create( testURLImage ).toURL().openStream() );
+			FileSystemUtil.write( testUpload, urlStream.readAllBytes(), true );
+		}
+
+		mockUploads.clear();
+
+		Stream.of( testFields ).forEach( field -> {
+			Path fieldFile = Path.of( tmpDirectory, field + ".jpg" );
+			try {
+				Files.copy( Path.of( testUpload ), fieldFile, StandardCopyOption.REPLACE_EXISTING );
+			} catch ( IOException e ) {
+				throw new BoxIOException( e );
+			}
+			mockUploads.add( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload( Key.of( field ), fieldFile, fieldFile.getFileName().toString() ) );
+		} );
+
+		ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload[] uploadsArray = mockUploads
+		    .toArray( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload[ 0 ] );
+
+		when( mockExchange.getUploadData() ).thenReturn( uploadsArray );
+
+	}
+
+	@DisplayName( "It tests the file component with upload" )
+	@Test
+	public void testComponentUpload() {
+		variables.put( Key.of( "filefield" ), testFields[ 0 ] );
+		variables.put( Key.directory, Path.of( tmpDirectory ).toAbsolutePath().toString() );
+		// @formatter:off
+		runtime.executeSource(
+		    """
+		    <cffile action="upload" filefield="#filefield#" destination="#directory#" nameconflict="makeunique" variable="result"/>
+		         """,
+		    context, BoxSourceType.CFTEMPLATE );
+		// @formatter:off
+
+		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
+
+		IStruct fileInfo = variables.getAsStruct( result );
+
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isInstanceOf( String.class );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isNotEmpty();
+		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
+		    .isEqualTo( Path.of( tmpDirectory, testFields[ 0 ] + ".jpg" ).toAbsolutePath().toString() );
+		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
+		    .isNotEqualTo( fileInfo.getAsString( KeyDictionary.serverFile ) );
+		assertThat( fileInfo.get( KeyDictionary.clientFileExt ) ).isEqualTo( "jpg" );
+		assertThat( fileInfo.get( KeyDictionary.contentType ) ).isEqualTo( "image/jpeg" );
+		assertThat( fileInfo.get( KeyDictionary.contentSubType ) ).isEqualTo( "jpeg" );
+		assertThat( fileInfo.get( KeyDictionary.fileSize ) ).isEqualTo( fileInfo.get( KeyDictionary.oldFileSize ) );
+
+	}
+
+	@DisplayName( "It tests the file component with uploadAll" )
+	@Test
+	public void testComponentUploadAll() {
+		System.out.println( mockUploads );
+		mockUploads.stream().forEach( upload -> {
+			assertTrue( Files.exists( upload.tmpPath() ) );
+		} );
+		variables.put( Key.directory, Path.of( tmpDirectory ).toAbsolutePath().toString() );
+		// @formatter:off
+		runtime.executeSource(
+		    """
+		    <cffile action="uploadAll" destination="#directory#" nameconflict="makeunique" variable="result"/>
+		         """,
+		    context, BoxSourceType.CFTEMPLATE );
+		// @formatter:off
+
+		assertThat( variables.get( result ) ).isInstanceOf( Array.class );
+
+		variables.getAsArray( result ).stream().map( StructCaster::cast ).forEach( fileInfo -> {
+			assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isInstanceOf( String.class );
+			assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isNotEmpty();
+			assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
+			    .isNotEqualTo( fileInfo.getAsString( KeyDictionary.serverFile ) );
+			assertThat( fileInfo.get( KeyDictionary.clientFileExt ) ).isEqualTo( "jpg" );
+			assertThat( fileInfo.get( KeyDictionary.contentType ) ).isEqualTo( "image/jpeg" );
+			assertThat( fileInfo.get( KeyDictionary.contentSubType ) ).isEqualTo( "jpeg" );
+			assertThat( fileInfo.get( KeyDictionary.fileSize ) ).isEqualTo( fileInfo.get( KeyDictionary.oldFileSize ) );
+		} );
+
+	}
+
+}

--- a/src/test/java/ortus/boxlang/web/components/FileTest.java
+++ b/src/test/java/ortus/boxlang/web/components/FileTest.java
@@ -62,7 +62,6 @@ public class FileTest extends ortus.boxlang.web.util.BaseWebTest {
 
 	@BeforeEach
 	public void setupUploads() throws IOException, URISyntaxException {
-		System.out.println( "Setting up uploads" );
 		if ( !FileSystemUtil.exists( testUpload ) ) {
 			BufferedInputStream urlStream = new BufferedInputStream( URI.create( testURLImage ).toURL().openStream() );
 			FileSystemUtil.write( testUpload, urlStream.readAllBytes(), true );
@@ -120,7 +119,6 @@ public class FileTest extends ortus.boxlang.web.util.BaseWebTest {
 	@DisplayName( "It tests the file component with uploadAll" )
 	@Test
 	public void testComponentUploadAll() {
-		System.out.println( mockUploads );
 		mockUploads.stream().forEach( upload -> {
 			assertTrue( Files.exists( upload.tmpPath() ) );
 		} );

--- a/src/test/java/ortus/boxlang/web/util/BaseWebTest.java
+++ b/src/test/java/ortus/boxlang/web/util/BaseWebTest.java
@@ -2,14 +2,16 @@ package ortus.boxlang.web.util;
 
 import static org.mockito.Mockito.when;
 
+import java.io.OutputStream;
+import java.io.PrintWriter;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.HashMap;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInstance;
 import org.mockito.Mockito;
 
 import ortus.boxlang.runtime.BoxRuntime;
@@ -21,25 +23,24 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.web.context.WebRequestBoxContext;
 import ortus.boxlang.web.exchange.BoxCookie;
 import ortus.boxlang.web.exchange.IBoxHTTPExchange;
+import ortus.boxlang.web.interceptors.WebRequest;
 
+@TestInstance( TestInstance.Lifecycle.PER_CLASS )
 public class BaseWebTest {
 
-	public static BoxRuntime	runtime;
-	public static Key			result			= new Key( "result" );
-	public static final String	TEST_WEBROOT	= Path.of( "src/test/resources/webroot" ).toAbsolutePath().toString();
+	public BoxRuntime			runtime;
+	public Key					result			= new Key( "result" );
+	public final String			TEST_WEBROOT	= Path.of( "src/test/resources/webroot" ).toAbsolutePath().toString();
 	public WebRequestBoxContext	context;
 	public IScope				variables;
 	public IBoxHTTPExchange		mockExchange;
 	public String				requestURI		= "/";
 
 	@BeforeAll
-	public static void setUp() {
+	public void setUp() {
 		runtime = BoxRuntime.getInstance( true );
-	}
-
-	@AfterAll
-	public static void teardown() {
-
+		// Manually register our interceptor as it doesn't automatically get registered in the test environment
+		runtime.getInterceptorService().register( new WebRequest() );
 	}
 
 	@BeforeEach
@@ -49,13 +50,11 @@ public class BaseWebTest {
 		// Mock some objects which are used in the context
 		when( mockExchange.getRequestCookies() ).thenReturn( new BoxCookie[ 0 ] );
 		when( mockExchange.getRequestHeaderMap() ).thenReturn( new HashMap<String, String[]>() );
+		when( mockExchange.getResponseWriter() ).thenReturn( new PrintWriter( OutputStream.nullOutputStream() ) );
 
 		// Create the mock contexts
 		context		= new WebRequestBoxContext( runtime.getRuntimeContext(), mockExchange, TEST_WEBROOT );
 		variables	= context.getScopeNearby( VariablesScope.name );
-
-		// Create the mock contexts
-		context		= new WebRequestBoxContext( runtime.getRuntimeContext(), mockExchange, TEST_WEBROOT );
 
 		try {
 			context.loadApplicationDescriptor( new URI( requestURI ) );
@@ -63,7 +62,6 @@ public class BaseWebTest {
 			throw new BoxRuntimeException( "Invalid URI", e );
 		}
 
-		variables = context.getScopeNearby( VariablesScope.name );
 		BaseApplicationListener appListener = context.getApplicationListener();
 		appListener.onRequestStart( context, new Object[] { requestURI } );
 	}

--- a/src/test/java/ortus/boxlang/web/util/BaseWebTest.java
+++ b/src/test/java/ortus/boxlang/web/util/BaseWebTest.java
@@ -16,6 +16,7 @@ import org.mockito.Mockito;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.application.BaseApplicationListener;
+import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -39,6 +40,10 @@ public class BaseWebTest {
 	@BeforeAll
 	public void setUp() {
 		runtime = BoxRuntime.getInstance( true );
+
+		// We need to unregister in the setup because the runtime is a singleton in the cli request
+		runtime.getInterceptorService().unregister( DynamicObject.of( new WebRequest() ) );
+
 		// Manually register our interceptor as it doesn't automatically get registered in the test environment
 		runtime.getInterceptorService().register( new WebRequest() );
 	}


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta9

### Improvement

[BL-414](https://ortussolutions.atlassian.net/browse/BL-414) Renaming of Box Cache functions to standardized \`cache\{function\}\(\)\`

[BL-415](https://ortussolutions.atlassian.net/browse/BL-415) Increase precision of math operations by using BigDecimal

[BL-421](https://ortussolutions.atlassian.net/browse/BL-421) Finalize FileUpload, FileUploadAll BIFs and File Component upload actions in Web Support

### Bug

[BL-405](https://ortussolutions.atlassian.net/browse/BL-405) BigIntegers cause error: integer number too large 

[BL-419](https://ortussolutions.atlassian.net/browse/BL-419) Not all unquoted tag attribute values are parsing

### New Feature

[BL-105](https://ortussolutions.atlassian.net/browse/BL-105) PDF Module

[BL-110](https://ortussolutions.atlassian.net/browse/BL-110) objectLoad\(\) and objectSave\(\) implemented and renamed to objectSerialize\(\) and objectDeserialize\(\)

[BL-420](https://ortussolutions.atlassian.net/browse/BL-420) Exit REPL with quit or exit

[BL-422](https://ortussolutions.atlassian.net/browse/BL-422) Ability to serialize BoxLang classes to binary and deserialize them back using it's state

[BL-423](https://ortussolutions.atlassian.net/browse/BL-423) New experimental features block on the \`boxlang.json\`

[BL-424](https://ortussolutions.atlassian.net/browse/BL-424) BoxRunner action commands now for: compile, cftranspile, featureAudit

[BL-414]: https://ortussolutions.atlassian.net/browse/BL-414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-415]: https://ortussolutions.atlassian.net/browse/BL-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-421]: https://ortussolutions.atlassian.net/browse/BL-421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-405]: https://ortussolutions.atlassian.net/browse/BL-405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-419]: https://ortussolutions.atlassian.net/browse/BL-419?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-105]: https://ortussolutions.atlassian.net/browse/BL-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-110]: https://ortussolutions.atlassian.net/browse/BL-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-420]: https://ortussolutions.atlassian.net/browse/BL-420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-422]: https://ortussolutions.atlassian.net/browse/BL-422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ