### PR TITLE
1.0.0-Beta10

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta9] - 2024-08-09
+
 ## [1.0.0-beta8] - 2024-08-02
 
 ## [1.0.0-beta7] - 2024-07-26
@@ -27,7 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta8...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta9...HEAD
+
+[1.0.0-beta9]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta8...v1.0.0-beta9
 
 [1.0.0-beta8]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta7...v1.0.0-beta8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Aug 02 16:05:05 UTC 2024
-boxlangVersion=1.0.0-beta9
+#Fri Aug 09 14:32:30 UTC 2024
+boxlangVersion=1.0.0-beta10
 jdkVersion=21
-version=1.0.0-beta9
+version=1.0.0-beta10
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/bifs/GetHTTPTimeString.java
+++ b/src/main/java/ortus/boxlang/web/bifs/GetHTTPTimeString.java
@@ -1,0 +1,72 @@
+
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.web.bifs;
+
+import java.time.ZoneId;
+import java.util.Set;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.DateTime;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.validation.Validator;
+
+@BoxBIF
+
+public class GetHTTPTimeString extends BIF {
+
+	/**
+	 * Constructor
+	 */
+	public GetHTTPTimeString() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( true, "any", Key.date, Set.of( Validator.typeOneOf( "datetime", "string" ) ) )
+		};
+	}
+
+	/**
+	 * Describe what the invocation of your bif function does
+	 *
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 *
+	 * @argument.foo Describe any expected arguments
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		DateTime dateRef = null;
+		try {
+			dateRef = arguments.getAsDateTime( Key.date );
+		} catch ( java.lang.ClassCastException e ) {
+			throw new BoxRuntimeException(
+			    String.format( "The provided date value [%s] could not be cast to a DateTime value", StringCaster.cast( arguments.get( Key.date ) ) ) );
+		}
+		DateTime converted = dateRef.convertToZone( ZoneId.of( "UTC" ) );
+		converted.setFormat( "EEE, dd MMM yyyy HH:mm:ss z" );
+
+		return converted.toString();
+
+	}
+
+}

--- a/src/test/java/ortus/boxlang/web/bifs/GetHTTPTimeStringTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/GetHTTPTimeStringTest.java
@@ -1,0 +1,77 @@
+
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.web.bifs;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.time.ZoneId;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.DateTime;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+
+public class GetHTTPTimeStringTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It tests the BIF GetHTTPTimeString" )
+	@Test
+	public void testBif() {
+		DateTime	dateRef		= new DateTime();
+		DateTime	converted	= dateRef.convertToZone( ZoneId.of( "UTC" ) );
+		converted.setFormat( "EEE, dd MMM yyyy HH:mm:ss z" );
+		String resultRef = converted.toString();
+		variables.put( Key.date, dateRef );
+		instance.executeSource( "result = getHttpTimeString( date );", context );
+		assertThat( variables.getAsString( result ) ).isEqualTo( resultRef );
+
+		assertThrows( BoxRuntimeException.class, () -> instance.executeSource( "result = getHttpTimeString( 'foo' );", context ) );
+	}
+
+}


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta10

### New Feature

[BL-435](https://ortussolutions.atlassian.net/browse/BL-435) transpile queryGetRow\(\) to queryRowData\(\) 

[BL-436](https://ortussolutions.atlassian.net/browse/BL-436) Ini files support

[BL-437](https://ortussolutions.atlassian.net/browse/BL-437) JSStringFormat BIF

[BL-439](https://ortussolutions.atlassian.net/browse/BL-439) xml component

[BL-442](https://ortussolutions.atlassian.net/browse/BL-442) getVariable\(\)

[BL-443](https://ortussolutions.atlassian.net/browse/BL-443) setVariable\(\)

[BL-444](https://ortussolutions.atlassian.net/browse/BL-444) Add getClientVariablesList\(\) to compat

[BL-445](https://ortussolutions.atlassian.net/browse/BL-445) add getClientVariablesList\(\) to compat

[BL-448](https://ortussolutions.atlassian.net/browse/BL-448) New getDescendantsOfType\(\) AST method with predicate

[BL-449](https://ortussolutions.atlassian.net/browse/BL-449) Implement single quote escapes in queries and preserveSingleQuotes

### Improvement

[BL-425](https://ortussolutions.atlassian.net/browse/BL-425) When doing class serialization make sure to identify which properties have \`serialize=false\` on them

[BL-426](https://ortussolutions.atlassian.net/browse/BL-426) content component can have body

[BL-429](https://ortussolutions.atlassian.net/browse/BL-429) Enhance error messages for parsing invalid tag code

[BL-440](https://ortussolutions.atlassian.net/browse/BL-440) Add isNumericDate BIF

[BL-441](https://ortussolutions.atlassian.net/browse/BL-441) Add getHTTPTimeString BIF to web-support

### Bug

[BL-143](https://ortussolutions.atlassian.net/browse/BL-143) Writedump label support

[BL-427](https://ortussolutions.atlassian.net/browse/BL-427) MalformedInputException: Input length = 1 when parsing CFC

[BL-428](https://ortussolutions.atlassian.net/browse/BL-428) component detection can be tricked if there is a tag comment line starting with the word "component"

[BL-432](https://ortussolutions.atlassian.net/browse/BL-432) Regression: Can't run files via BoxRunner due to new action command logic

[BL-447](https://ortussolutions.atlassian.net/browse/BL-447) java.math.BigInteger caster

[BL-451](https://ortussolutions.atlassian.net/browse/BL-451) Sometimes trying to shutdown runtime throws NPE if it was never started fully

[BL-452](https://ortussolutions.atlassian.net/browse/BL-452) pretty print visitor outputting extra " on tag catch block

[BL-453](https://ortussolutions.atlassian.net/browse/BL-453) pretty print visitor doesn't handle array notation invocation

### Task

[BL-450](https://ortussolutions.atlassian.net/browse/BL-450) Allow .cfm and .cfs files from the boxlang CLI runner

[BL-435]: https://ortussolutions.atlassian.net/browse/BL-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-436]: https://ortussolutions.atlassian.net/browse/BL-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-437]: https://ortussolutions.atlassian.net/browse/BL-437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-439]: https://ortussolutions.atlassian.net/browse/BL-439?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-442]: https://ortussolutions.atlassian.net/browse/BL-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-443]: https://ortussolutions.atlassian.net/browse/BL-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-444]: https://ortussolutions.atlassian.net/browse/BL-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-445]: https://ortussolutions.atlassian.net/browse/BL-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-448]: https://ortussolutions.atlassian.net/browse/BL-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-449]: https://ortussolutions.atlassian.net/browse/BL-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-425]: https://ortussolutions.atlassian.net/browse/BL-425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ