### PR TITLE
1.0.0-Beta13

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta12] - 2024-08-30
+
 ## [1.0.0-beta11] - 2024-08-23
 
 ## [1.0.0-beta10] - 2024-08-16
@@ -33,7 +35,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta11...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta12...HEAD
+
+[1.0.0-beta12]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta11...v1.0.0-beta12
 
 [1.0.0-beta11]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta10...v1.0.0-beta11
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Aug 23 12:59:34 UTC 2024
-boxlangVersion=1.0.0-beta12
+#Fri Aug 30 16:53:11 UTC 2024
+boxlangVersion=1.0.0-beta13
 jdkVersion=21
-version=1.0.0-beta12
+version=1.0.0-beta13
 group=ortus.boxlang


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta13

### Improvement

[BL-497](https://ortussolutions.atlassian.net/browse/BL-497) Simplify BoxLang class dumps

[BL-499](https://ortussolutions.atlassian.net/browse/BL-499) Add output and format to dump

[BL-501](https://ortussolutions.atlassian.net/browse/BL-501) Some BIFs not fully supporting BigDecimal values

[BL-517](https://ortussolutions.atlassian.net/browse/BL-517) access e.cause as shortcut for e.getCause\(\)

[BL-518](https://ortussolutions.atlassian.net/browse/BL-518) When creating an abstract class a new \`AbstractClassException\` is thrown. Great for testing frameworks

### Bug

[BL-223](https://ortussolutions.atlassian.net/browse/BL-223) queryaddcolumn ignores the datatype

[BL-471](https://ortussolutions.atlassian.net/browse/BL-471) Issue with #dateTimeFormat\(now\(\),'mm-dd-yyyy'\)# function returning incorrect results

[BL-492](https://ortussolutions.atlassian.net/browse/BL-492) structnew\( "linked" \) doesn't work

[BL-493](https://ortussolutions.atlassian.net/browse/BL-493) argumentCollection doesn't work with implicit constructor

[BL-494](https://ortussolutions.atlassian.net/browse/BL-494) directory component must always return query

[BL-498](https://ortussolutions.atlassian.net/browse/BL-498) BoxNewTransformer using hard-coded context name

[BL-500](https://ortussolutions.atlassian.net/browse/BL-500) toNumeric\(\) not accepting radix values of 2-36

[BL-502](https://ortussolutions.atlassian.net/browse/BL-502) cannot cast \[x to object\] on generic caster when using \`QuerySetCell\(\)\`

[BL-505](https://ortussolutions.atlassian.net/browse/BL-505) Issue with \`Duplicate\(\)\` Function Causing Null Pointer Exception in BoxLang

[BL-506](https://ortussolutions.atlassian.net/browse/BL-506) final keyword not working on this scope

[BL-509](https://ortussolutions.atlassian.net/browse/BL-509) directoryList\(\) filters are not working as closures/lambdas as they are hardcoded as strings

[BL-510](https://ortussolutions.atlassian.net/browse/BL-510) Cannot invoke "ortus.boxlang.runtime.types.Query.isEmpty\(\)" because "this.query" is null

[BL-511](https://ortussolutions.atlassian.net/browse/BL-511) Multiple pipe-delimited glob patterns are not working as directoryList filters

[BL-512](https://ortussolutions.atlassian.net/browse/BL-512) DuplicationUtil not doing deep clones of structs according to all types

[BL-513](https://ortussolutions.atlassian.net/browse/BL-513) Throwing custom type exceptions just shows \`custom\` as the type instead of the actual type in the throw

[BL-514](https://ortussolutions.atlassian.net/browse/BL-514) remote access not treated as public but as private for functions

[BL-515](https://ortussolutions.atlassian.net/browse/BL-515) Interfaces don't support multiple inheritance

[BL-516](https://ortussolutions.atlassian.net/browse/BL-516) CFC source type not detected correctly for abstract or final classes

[BL-521](https://ortussolutions.atlassian.net/browse/BL-521) Metadata with : in them in cfml mode not treated correctly

[BL-522](https://ortussolutions.atlassian.net/browse/BL-522) xml entity parsing issue when calling \`toString\(\)\` on Java objects

### New Feature

[BL-142](https://ortussolutions.atlassian.net/browse/BL-142) Writedump output support

[BL-489](https://ortussolutions.atlassian.net/browse/BL-489) Ability to mark a @BoxBif as excluded from documentation

[BL-504](https://ortussolutions.atlassian.net/browse/BL-504) New dump template for Java instants

[BL-507](https://ortussolutions.atlassian.net/browse/BL-507) dump showUDFs 

[BL-508](https://ortussolutions.atlassian.net/browse/BL-508) New dump event to listen when an non-core output is detected so modules can handle it. \`onMissingDumpOutput\`