### PR TITLE
1.0.0-Beta14

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta13] - 2024-09-06
+
 ## [1.0.0-beta12] - 2024-08-30
 
 ## [1.0.0-beta11] - 2024-08-23
@@ -35,7 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First iteration of this module
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta12...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta13...HEAD
+
+[1.0.0-beta13]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta12...v1.0.0-beta13
 
 [1.0.0-beta12]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta11...v1.0.0-beta12
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Aug 30 16:53:11 UTC 2024
-boxlangVersion=1.0.0-beta13
+#Fri Sep 06 12:08:27 UTC 2024
+boxlangVersion=1.0.0-beta14
 jdkVersion=21
-version=1.0.0-beta13
+version=1.0.0-beta14
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/WebRequestExecutor.java
+++ b/src/main/java/ortus/boxlang/web/WebRequestExecutor.java
@@ -126,7 +126,13 @@ public class WebRequestExecutor {
 
 			// Finally flush the buffer
 			context.flushBuffer( false );
-		} catch ( AbortException e ) {
+		}
+		/**
+		 * --------------------------------------------------------------------------------
+		 * DEAL WITH BX ABORTS
+		 * --------------------------------------------------------------------------------
+		 */
+		catch ( AbortException e ) {
 			ensureContentType( exchange, DEFAULT_CONTENT_TYPE );
 
 			if ( appListener != null ) {
@@ -146,7 +152,13 @@ public class WebRequestExecutor {
 				// This will always be an instance of CustomException
 				throw ( RuntimeException ) e.getCause();
 			}
-		} catch ( MissingIncludeException e ) {
+		}
+		/**
+		 * --------------------------------------------------------------------------------
+		 * MISSING INCLUDES HANDLING
+		 * --------------------------------------------------------------------------------
+		 */
+		catch ( MissingIncludeException e ) {
 			ensureContentType( exchange, DEFAULT_CONTENT_TYPE );
 			try {
 				// A return of true means the error has been "handled". False means the default
@@ -165,9 +177,21 @@ public class WebRequestExecutor {
 			if ( context != null ) {
 				context.flushBuffer( false );
 			}
-		} catch ( Throwable e ) {
+		}
+		/**
+		 * --------------------------------------------------------------------------------
+		 * ALL OTHER ERRORS
+		 * --------------------------------------------------------------------------------
+		 */
+		catch ( Throwable e ) {
 			errorToHandle = e;
-		} finally {
+		}
+		/**
+		 * --------------------------------------------------------------------------------
+		 * DEAL WITH ALL THE ERRORS HERE
+		 * --------------------------------------------------------------------------------
+		 */
+		finally {
 			ensureContentType( exchange, DEFAULT_CONTENT_TYPE );
 			if ( appListener != null ) {
 				try {

--- a/src/main/java/ortus/boxlang/web/WebRequestExecutor.java
+++ b/src/main/java/ortus/boxlang/web/WebRequestExecutor.java
@@ -128,6 +128,7 @@ public class WebRequestExecutor {
 			context.flushBuffer( false );
 		} catch ( AbortException e ) {
 			ensureContentType( exchange, DEFAULT_CONTENT_TYPE );
+
 			if ( appListener != null ) {
 				try {
 					appListener.onAbort( context, new Object[] { requestString } );
@@ -136,8 +137,11 @@ public class WebRequestExecutor {
 					errorToHandle = ae;
 				}
 			}
-			if ( context != null )
+
+			if ( context != null ) {
 				context.flushBuffer( true );
+			}
+
 			if ( e.getCause() != null ) {
 				// This will always be an instance of CustomException
 				throw ( RuntimeException ) e.getCause();
@@ -157,8 +161,10 @@ public class WebRequestExecutor {
 				// Opps, an error while handling the missing template error
 				errorToHandle = t;
 			}
-			if ( context != null )
+
+			if ( context != null ) {
 				context.flushBuffer( false );
+			}
 		} catch ( Throwable e ) {
 			errorToHandle = e;
 		} finally {
@@ -171,8 +177,10 @@ public class WebRequestExecutor {
 					errorToHandle = e;
 				}
 			}
-			if ( context != null )
+
+			if ( context != null ) {
 				context.flushBuffer( false );
+			}
 
 			if ( errorToHandle != null ) {
 				try {

--- a/src/main/java/ortus/boxlang/web/WebRequestExecutor.java
+++ b/src/main/java/ortus/boxlang/web/WebRequestExecutor.java
@@ -119,12 +119,12 @@ public class WebRequestExecutor {
 						case null, default -> "text/html;charset=UTF-8";
 					} );
 				} else {
+					ensureContentType( exchange, DEFAULT_CONTENT_TYPE );
 					appListener.onRequest( context, new Object[] { requestString } );
 				}
 			}
 
-			// Ensure content and request flush
-			ensureContentType( exchange, DEFAULT_CONTENT_TYPE );
+			// Finally flush the buffer
 			context.flushBuffer( false );
 		} catch ( AbortException e ) {
 			ensureContentType( exchange, DEFAULT_CONTENT_TYPE );

--- a/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
+++ b/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
@@ -14,6 +14,8 @@
  */
 package ortus.boxlang.web.bifs;
 
+import java.util.Map;
+
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
@@ -136,6 +138,14 @@ public class GetPageContext extends BIF {
 
 		public void addHeader( String name, String value ) {
 			setHeader( name, value );
+		}
+
+		public Map<String, String[]> getRequestHeaderMap() {
+			return exchange.getRequestHeaderMap();
+		}
+
+		public String getRequestHeader( String name ) {
+			return exchange.getRequestHeader( name );
 		}
 
 	}

--- a/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
+++ b/src/main/java/ortus/boxlang/web/bifs/GetPageContext.java
@@ -140,6 +140,14 @@ public class GetPageContext extends BIF {
 			setHeader( name, value );
 		}
 
+		public Map<String, String[]> getResponseHeaderMap() {
+			return exchange.getResponseHeaderMap();
+		}
+
+		public String getResponseHeader( String name ) {
+			return exchange.getResponseHeader( name );
+		}
+
 		public Map<String, String[]> getRequestHeaderMap() {
 			return exchange.getRequestHeaderMap();
 		}

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -158,6 +158,10 @@ public class WebRequestBoxContext extends RequestBoxContext {
 		}
 	}
 
+	/**
+	 * @inheritDoc
+	 */
+	@Override
 	public IStruct getVisibleScopes( IStruct scopes, boolean nearby, boolean shallow ) {
 		if ( hasParent() && !shallow ) {
 			getParent().getVisibleScopes( scopes, false, false );
@@ -320,6 +324,10 @@ public class WebRequestBoxContext extends RequestBoxContext {
 		return getScope( name );
 	}
 
+	/**
+	 * @inheritDoc
+	 */
+	@Override
 	public void registerUDF( UDF udf, boolean override ) {
 		registerUDF( variablesScope, udf, override );
 	}


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta14

### Bug

[BL-496](https://ortussolutions.atlassian.net/browse/BL-496) replace and replaceNoCase functions do not accept a callback

[BL-519](https://ortussolutions.atlassian.net/browse/BL-519) Query dereferencing is not working correctly: Column '1' does not exist in query

[BL-520](https://ortussolutions.atlassian.net/browse/BL-520) Run Class via URL

[BL-523](https://ortussolutions.atlassian.net/browse/BL-523) A class which uses inheritance, the metadata includes the inherited functions in itself and parent.

[BL-524](https://ortussolutions.atlassian.net/browse/BL-524) reFindNoCase\( "^\(f|x\)?test$", arguments.methodName \) fails with  Cannot invoke "String.length\(\)" because the return value of "java.util.regex.Matcher.group\(int\)" is null

[BL-525](https://ortussolutions.atlassian.net/browse/BL-525) lsParseDateTime errors when given locale and mask

[BL-526](https://ortussolutions.atlassian.net/browse/BL-526) dateformat incorrectly parsing date with leading 0's?

[BL-527](https://ortussolutions.atlassian.net/browse/BL-527) onMissingMethod is not firing if the execution of the method is from within the class

[BL-528](https://ortussolutions.atlassian.net/browse/BL-528) query dumps assume the value is simple and can explode with encodeForHTML\(\) can't do complex objects

[BL-530](https://ortussolutions.atlassian.net/browse/BL-530) Improve tracking of class in function box context

[BL-531](https://ortussolutions.atlassian.net/browse/BL-531) Difference of behavior with cfdirectory recurse = true not including path

[BL-532](https://ortussolutions.atlassian.net/browse/BL-532) super long strings cause compilation errors due to limitations in Java source code

[BL-533](https://ortussolutions.atlassian.net/browse/BL-533) Errors in miniserver when flushing large amounts of output to buffer

[BL-534](https://ortussolutions.atlassian.net/browse/BL-534) Missing !== operator

[BL-535](https://ortussolutions.atlassian.net/browse/BL-535) query cell assign erroring

[BL-537](https://ortussolutions.atlassian.net/browse/BL-537) Add onBifInvocation Interception Announcement to BIF invoke method

### Improvement

[BL-228](https://ortussolutions.atlassian.net/browse/BL-228) Consolidate/Rename "LS" Bifs and Move US-Centric ones to Compat

[BL-409](https://ortussolutions.atlassian.net/browse/BL-409) Member method cleanup

[BL-410](https://ortussolutions.atlassian.net/browse/BL-410) Improve REPL output of native Java arrays

[BL-541](https://ortussolutions.atlassian.net/browse/BL-541) Add "decimal" as a cast type

### New Feature

[BL-93](https://ortussolutions.atlassian.net/browse/BL-93) Create immutable query type

[BL-529](https://ortussolutions.atlassian.net/browse/BL-529) Announce the onBXDump whenever a dump is about to be rendered, to allow for external listeners to receive the dump

[BL-536](https://ortussolutions.atlassian.net/browse/BL-536) New server keys: executionCommand, executionArgs to assist with CLI tooling

[BL-538](https://ortussolutions.atlassian.net/browse/BL-538) New runtime inCLIMode\(\) method to tell you if the runtime was started via the runtime or something else

[BL-539](https://ortussolutions.atlassian.net/browse/BL-539) New server.cli key to provide you with all the CLI options used to run the runtime

[BL-540](https://ortussolutions.atlassian.net/browse/BL-540) Refactor the CLIOptions to it's own class and add a simple argument parser

[BL-496]: https://ortussolutions.atlassian.net/browse/BL-496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-519]: https://ortussolutions.atlassian.net/browse/BL-519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-520]: https://ortussolutions.atlassian.net/browse/BL-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-523]: https://ortussolutions.atlassian.net/browse/BL-523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-524]: https://ortussolutions.atlassian.net/browse/BL-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-525]: https://ortussolutions.atlassian.net/browse/BL-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-526]: https://ortussolutions.atlassian.net/browse/BL-526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-527]: https://ortussolutions.atlassian.net/browse/BL-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ