### PR TITLE
1.0.0-Beta20

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta19] - 2024-10-18
+
 ## [1.0.0-beta18] - 2024-10-11
 
 ## [1.0.0-beta17] - 2024-10-04
@@ -79,7 +81,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.0.0-beta1]: https://github.com/ortus-boxlang/boxlang-web-support/compare/36688119b6956a927323667c1672e2ac7bab540e...v1.0.0-beta1
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta18...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta19...HEAD
+
+[1.0.0-beta19]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta15...v1.0.0-beta19
 
 [1.0.0-beta18]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta15...v1.0.0-beta18
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Oct 11 15:30:28 UTC 2024
-boxlangVersion=1.0.0-beta19
+#Fri Oct 18 14:58:47 UTC 2024
+boxlangVersion=1.0.0-beta20
 jdkVersion=21
-version=1.0.0-beta19
+version=1.0.0-beta20
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/WebRequestExecutor.java
+++ b/src/main/java/ortus/boxlang/web/WebRequestExecutor.java
@@ -30,7 +30,6 @@ import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.exceptions.AbortException;
 import ortus.boxlang.runtime.types.exceptions.MissingIncludeException;
-import ortus.boxlang.runtime.util.FQN;
 import ortus.boxlang.runtime.util.BoxFQN;
 import ortus.boxlang.runtime.util.FRTransService;
 import ortus.boxlang.web.context.WebRequestBoxContext;
@@ -71,6 +70,7 @@ public class WebRequestExecutor {
 
 			// Load up the runtime, context and app listener
 			context			= new WebRequestBoxContext( BoxRuntime.getInstance().getRuntimeContext(), exchange, webRoot );
+			RequestBoxContext.setCurrent( context );
 			context.loadApplicationDescriptor( new URI( requestString ) );
 			appListener = context.getApplicationListener();
 
@@ -102,11 +102,15 @@ public class WebRequestExecutor {
 						returnFormat = args.get( Key.returnFormat ).toString();
 						args.remove( Key.returnFormat );
 					}
-					appListener.onClassRequest( context, new Object[] { new BoxFQN( requestPath ).toString(), methodName, args, returnFormat } );
-					// If return format was passed in the URL, then we know it was chosen. If none in the URL, one may have been set on the remote functions
+					appListener.onClassRequest( context,
+					    new Object[] { new BoxFQN( requestPath ).toString(), methodName, args, returnFormat } );
+					// If return format was passed in the URL, then we know it was chosen. If none
+					// in the URL, one may have been set on the remote functions
 					// annotations
 					if ( returnFormat == null ) {
-						returnFormat = Optional.ofNullable( context.getParentOfType( RequestBoxContext.class ).getAttachment( Key.returnFormat ) )
+						returnFormat = Optional
+						    .ofNullable( context.getParentOfType( RequestBoxContext.class )
+						        .getAttachment( Key.returnFormat ) )
 						    .map( Object::toString )
 						    .orElse( "plain" );
 					}
@@ -229,6 +233,7 @@ public class WebRequestExecutor {
 			if ( frTransService != null ) {
 				frTransService.endTransaction( trans );
 			}
+			RequestBoxContext.removeCurrent();
 		}
 	}
 

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -158,7 +158,10 @@ public class WebRequestBoxContext extends RequestBoxContext {
 						// Otherwise generate a new one
 						this.sessionID = Key.of( UUID.randomUUID().toString() );
 						// TODO: secure, domain, etc
-						httpExchange.addResponseCookie( new BoxCookie( "jsessionid", sessionID.getName() ) );
+						httpExchange.addResponseCookie(
+						    new BoxCookie( "jsessionid", sessionID.getName() )
+						        .setPath( "/" )
+						);
 					}
 				}
 			}

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -89,7 +89,15 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 */
 	protected Object			requestBody		= null;
 
+	/**
+	 * The web root for this request
+	 */
 	protected String			webRoot;
+
+	/**
+	 * The session ID for this request
+	 */
+	protected Key				sessionID		= null;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -130,22 +138,33 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 */
 
 	/**
-	 * Get the session key for this request
+	 * Get the session key for this request, creating if neccessary
 	 *
 	 * @return The session key
 	 */
 	public Key getSessionID() {
-		// TODO: make this logic configurable
-		BoxCookie	sessionCookie	= httpExchange.getRequestCookie( "jsessionid" );
-		String		sessionID;
-		if ( sessionCookie != null ) {
-			sessionID = sessionCookie.getValue();
-		} else {
-			sessionID = UUID.randomUUID().toString();
-			// TODO: secure, domain, etc
-			httpExchange.addResponseCookie( new BoxCookie( "jsessionid", sessionID ) );
+		// Only look if this is the first time for this request
+		if ( this.sessionID == null ) {
+			// Double check lock pattern for threading safety
+			synchronized ( this ) {
+				// double check...
+				if ( this.sessionID == null ) {
+					// Look in a request cookie
+					// TODO: make cookie name configurable
+					BoxCookie sessionCookie = httpExchange.getRequestCookie( "jsessionid" );
+					if ( sessionCookie != null ) {
+						this.sessionID = Key.of( sessionCookie.getValue() );
+					} else {
+						// Otherwise generate a new one
+						this.sessionID = Key.of( UUID.randomUUID().toString() );
+						// TODO: secure, domain, etc
+						httpExchange.addResponseCookie( new BoxCookie( "jsessionid", sessionID.getName() ) );
+					}
+				}
+			}
 		}
-		return Key.of( sessionID );
+		// assert the sessionID has been defined now
+		return this.sessionID;
 	}
 
 	/**
@@ -153,6 +172,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 */
 	public void resetSession() {
 		synchronized ( this ) {
+			this.sessionID = null;
 			httpExchange.addResponseCookie( new BoxCookie( "jsessionid", null ) );
 			getApplicationListener().invalidateSession( getSessionID() );
 		}


### PR DESCRIPTION
New Feature
BL-117 trace bif and component
BL-670 Setup the thread's context class loader when an application is defined with the correct loader from the Applications java settings
BL-684 showDebugOuput added to request box context to allow for tracer/debugging outputs
BL-688 new computeAttachmentIfAbsent, to make fluent attachments on IBoxAttachable implementations
BL-689 refactor escapeHTML to the lib we use instead of multiple functions
BL-698 DateTime objects don't have a len member method
Improvements
BL-672 Add line break in dump console output
BL-673 Allow access to super scope from thread
BL-683 reuse config of validTemplateExtensions
BL-686 Add ability to deep merge config items from the environment.
BL-687 track current request context in thread
BL-690 improve concurrency of session ID creation
BL-693 Move from immutable verbiage to unmodifiable
BL-703 Need to set explicit `/` path on session cookies
BL-707 if calling serializeJSON() on a class, and the class is marked as not serializable, then return empty struct
BL-708 if calling serializeJSON() on a class, properties marked as not serialiable should be skipped.
BL-709 Arrays/Lists/Structs/Maps/Classes that have been visited already by JSON will not serialize again but show a recursion marker
Bugs
BL-640 bx-compat-cfml datediff fails to convert string
BL-645 Update parser to allow for `@module` notations on imports and `new` operators
BL-663 NOT operator precedence not grabbing operators in the chain
BL-668 Java Doc implementation is stricter that ACF and Lucee
BL-671 Missed module class hierarchy to have the runtime class loader as the parent
BL-675 ortus.boxlang.runtime.events.InterceptorPool: Errors announcing [logMessage] interception ortus.boxlang.runtime.types.exceptions.BoxRuntimeException: An error occurred while attempting to log the message
BL-676 Dump not showing BoxLang type NullValue as null
BL-678 DBInfo schema and several other columns can be null, make sure you address it
BL-680 boxclass dump looping construct exception
BL-696 java class method not found
BL-697 argument collection optional param is null
BL-701 Cannot convert class ortus.boxlang.runtime.types.DateTime to SQL type requested due to com.mysql.cj.exceptions.WrongArgumentException - Conversion from ortus.boxlang.runtime.types.DateTime to TIMESTAMP is not supported.
BL-702 DatabaseException: There is no known date-time pattern for '09/24/2024' value at ortus.boxlang.runtime.jdbc.PendingQuery.executeStatement(PendingQuery.java:390)
BL-704 cannot get lenght of native java date time objects
BL-705 Can't cast [2021-01-01 12:00:00 pm] to a DateTime.