### PR TITLE
Version bump

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta22] - 2024-11-15
+
 ## [1.0.0-beta21] - 2024-11-01
 
 ## [1.0.0-beta20] - 2024-10-25
@@ -85,7 +87,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.0.0-beta1]: https://github.com/ortus-boxlang/boxlang-web-support/compare/36688119b6956a927323667c1672e2ac7bab540e...v1.0.0-beta1
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta21...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta22...HEAD
+
+[1.0.0-beta22]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta15...v1.0.0-beta22
 
 [1.0.0-beta21]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta15...v1.0.0-beta21
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Nov 01 20:47:08 UTC 2024
-boxlangVersion=1.0.0-beta22
+#Fri Nov 15 22:15:54 UTC 2024
+boxlangVersion=1.0.0-beta23
 jdkVersion=21
-version=1.0.0-beta22
+version=1.0.0-beta23
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -45,7 +45,7 @@ import ortus.boxlang.web.scopes.URLScope;
  */
 public class WebRequestBoxContext extends RequestBoxContext {
 
-	private static BoxRuntime	runtime			= BoxRuntime.getInstance();
+	private static BoxRuntime runtime = BoxRuntime.getInstance();
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -56,49 +56,49 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	/**
 	 * The variables scope
 	 */
-	protected IScope			variablesScope	= new VariablesScope();
+	protected IScope variablesScope = new VariablesScope();
 
 	/**
 	 * The request scope
 	 */
-	protected IScope			requestScope;
+	protected IScope requestScope;
 
 	/**
 	 * The URL scope
 	 */
-	protected IScope			URLScope;
+	protected IScope URLScope;
 
 	/**
 	 * The form scope
 	 */
-	protected IScope			formScope;
+	protected IScope formScope;
 
 	/**
 	 * The CGI scope
 	 */
-	protected IScope			CGIScope;
+	protected IScope CGIScope;
 
 	/**
 	 * The cookie scope
 	 */
-	protected IScope			cookieScope;
+	protected IScope cookieScope;
 
-	protected IBoxHTTPExchange	httpExchange;
+	protected IBoxHTTPExchange httpExchange;
 
 	/**
 	 * The request body can only be read once, so we cache it here
 	 */
-	protected Object			requestBody		= null;
+	protected Object requestBody = null;
 
 	/**
 	 * The web root for this request
 	 */
-	protected String			webRoot;
+	protected String webRoot;
 
 	/**
 	 * The session ID for this request
 	 */
-	protected Key				sessionID		= null;
+	protected Key sessionID = null;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -107,29 +107,31 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 */
 
 	/**
-	 * Creates a new execution context with a bounded execution template and parent context
+	 * Creates a new execution context with a bounded execution template and parent
+	 * context
 	 *
 	 * @param parent The parent context
 	 */
-	public WebRequestBoxContext( IBoxContext parent, IBoxHTTPExchange httpExchange, String webRoot, URI template ) {
-		super( parent );
-		httpExchange.setWebContext( this );
-		this.httpExchange	= httpExchange;
-		this.webRoot		= webRoot;
-		URLScope			= new URLScope( httpExchange );
-		formScope			= new FormScope( httpExchange );
-		CGIScope			= new CGIScope( httpExchange );
-		cookieScope			= new CookieScope( httpExchange );
-		requestScope		= new RequestScope( httpExchange );
+	public WebRequestBoxContext(IBoxContext parent, IBoxHTTPExchange httpExchange, String webRoot, URI template) {
+		super(parent);
+		httpExchange.setWebContext(this);
+		this.httpExchange = httpExchange;
+		this.webRoot = webRoot;
+		URLScope = new URLScope(httpExchange);
+		formScope = new FormScope(httpExchange);
+		CGIScope = new CGIScope(httpExchange);
+		cookieScope = new CookieScope(httpExchange);
+		requestScope = new RequestScope(httpExchange);
 	}
 
 	/**
-	 * Creates a new execution context with a bounded execution template and parent context
+	 * Creates a new execution context with a bounded execution template and parent
+	 * context
 	 *
 	 * @param parent The parent context
 	 */
-	public WebRequestBoxContext( IBoxContext parent, IBoxHTTPExchange exchange, String webRoot ) {
-		this( parent, exchange, webRoot, null );
+	public WebRequestBoxContext(IBoxContext parent, IBoxHTTPExchange exchange, String webRoot) {
+		this(parent, exchange, webRoot, null);
 	}
 
 	/**
@@ -145,24 +147,23 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 */
 	public Key getSessionID() {
 		// Only look if this is the first time for this request
-		if ( this.sessionID == null ) {
+		if (this.sessionID == null) {
 			// Double check lock pattern for threading safety
-			synchronized ( this ) {
+			synchronized (this) {
 				// double check...
-				if ( this.sessionID == null ) {
+				if (this.sessionID == null) {
 					// Look in a request cookie
 					// TODO: make cookie name configurable
-					BoxCookie sessionCookie = httpExchange.getRequestCookie( "jsessionid" );
-					if ( sessionCookie != null ) {
-						this.sessionID = Key.of( sessionCookie.getValue() );
+					BoxCookie sessionCookie = httpExchange.getRequestCookie("jsessionid");
+					if (sessionCookie != null) {
+						this.sessionID = Key.of(sessionCookie.getValue());
 					} else {
 						// Otherwise generate a new one
-						this.sessionID = Key.of( UUID.randomUUID().toString() );
+						this.sessionID = Key.of(UUID.randomUUID().toString());
 						// TODO: secure, domain, etc
 						httpExchange.addResponseCookie(
-						    new BoxCookie( "jsessionid", sessionID.getName() )
-						        .setPath( "/" )
-						);
+								new BoxCookie("jsessionid", sessionID.getName())
+										.setPath("/"));
 					}
 				}
 			}
@@ -175,10 +176,10 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * Invalidate a session
 	 */
 	public void resetSession() {
-		synchronized ( this ) {
+		synchronized (this) {
 			this.sessionID = null;
-			httpExchange.addResponseCookie( new BoxCookie( "jsessionid", null ) );
-			getApplicationListener().invalidateSession( getSessionID() );
+			httpExchange.addResponseCookie(new BoxCookie("jsessionid", null));
+			getApplicationListener().invalidateSession(getSessionID());
 		}
 	}
 
@@ -186,19 +187,19 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * @inheritDoc
 	 */
 	@Override
-	public IStruct getVisibleScopes( IStruct scopes, boolean nearby, boolean shallow ) {
-		if ( hasParent() && !shallow ) {
-			getParent().getVisibleScopes( scopes, false, false );
+	public IStruct getVisibleScopes(IStruct scopes, boolean nearby, boolean shallow) {
+		if (hasParent() && !shallow) {
+			getParent().getVisibleScopes(scopes, false, false);
 		}
-		scopes.getAsStruct( Key.contextual ).put( ortus.boxlang.web.scopes.URLScope.name, URLScope );
-		scopes.getAsStruct( Key.contextual ).put( FormScope.name, formScope );
-		scopes.getAsStruct( Key.contextual ).put( ortus.boxlang.web.scopes.CGIScope.name, CGIScope );
-		scopes.getAsStruct( Key.contextual ).put( CookieScope.name, cookieScope );
-		scopes.getAsStruct( Key.contextual ).put( RequestScope.name, requestScope );
-		if ( nearby ) {
-			scopes.getAsStruct( Key.contextual ).put( VariablesScope.name, variablesScope );
+		scopes.getAsStruct(Key.contextual).put(ortus.boxlang.web.scopes.URLScope.name, URLScope);
+		scopes.getAsStruct(Key.contextual).put(FormScope.name, formScope);
+		scopes.getAsStruct(Key.contextual).put(ortus.boxlang.web.scopes.CGIScope.name, CGIScope);
+		scopes.getAsStruct(Key.contextual).put(CookieScope.name, cookieScope);
+		scopes.getAsStruct(Key.contextual).put(RequestScope.name, requestScope);
+		if (nearby) {
+			scopes.getAsStruct(Key.contextual).put(VariablesScope.name, variablesScope);
 		}
-		return super.getVisibleScopes( scopes, nearby, shallow );
+		return super.getVisibleScopes(scopes, nearby, shallow);
 	}
 
 	/**
@@ -212,27 +213,27 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 *
 	 */
 	@Override
-	public ScopeSearchResult scopeFindNearby( Key key, IScope defaultScope, boolean shallow ) {
+	public ScopeSearchResult scopeFindNearby(Key key, IScope defaultScope, boolean shallow) {
 
 		// In query loop?
-		var querySearch = queryFindNearby( key );
-		if ( querySearch != null ) {
+		var querySearch = queryFindNearby(key);
+		if (querySearch != null) {
 			return querySearch;
 		}
 
 		// In Variables scope? (thread-safe lookup and get)
-		Object result = variablesScope.getRaw( key );
+		Object result = variablesScope.getRaw(key);
 		// Null means not found
-		if ( isDefined( result ) ) {
+		if (isDefined(result)) {
 			// Unwrap the value now in case it was really actually null for real
-			return new ScopeSearchResult( variablesScope, Struct.unWrapNull( result ), key );
+			return new ScopeSearchResult(variablesScope, Struct.unWrapNull(result), key);
 		}
 
-		if ( shallow ) {
+		if (shallow) {
 			return null;
 		}
 
-		return scopeFind( key, defaultScope );
+		return scopeFind(key, defaultScope);
 	}
 
 	/**
@@ -247,45 +248,45 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 *
 	 */
 	@Override
-	public ScopeSearchResult scopeFind( Key key, IScope defaultScope ) {
+	public ScopeSearchResult scopeFind(Key key, IScope defaultScope) {
 
-		if ( key.equals( requestScope.getName() ) ) {
-			return new ScopeSearchResult( requestScope, requestScope, key, true );
+		if (key.equals(requestScope.getName())) {
+			return new ScopeSearchResult(requestScope, requestScope, key, true);
 		}
-		if ( key.equals( CGIScope.getName() ) ) {
-			return new ScopeSearchResult( CGIScope, CGIScope, key, true );
+		if (key.equals(CGIScope.getName())) {
+			return new ScopeSearchResult(CGIScope, CGIScope, key, true);
 		}
-		if ( key.equals( URLScope.getName() ) ) {
-			return new ScopeSearchResult( URLScope, URLScope, key, true );
+		if (key.equals(URLScope.getName())) {
+			return new ScopeSearchResult(URLScope, URLScope, key, true);
 		}
-		if ( key.equals( formScope.getName() ) ) {
-			return new ScopeSearchResult( formScope, formScope, key, true );
+		if (key.equals(formScope.getName())) {
+			return new ScopeSearchResult(formScope, formScope, key, true);
 		}
-		if ( key.equals( cookieScope.getName() ) ) {
-			return new ScopeSearchResult( cookieScope, cookieScope, key, true );
+		if (key.equals(cookieScope.getName())) {
+			return new ScopeSearchResult(cookieScope, cookieScope, key, true);
 		}
-		Object result = CGIScope.getRaw( key );
+		Object result = CGIScope.getRaw(key);
 		// Null means not found
-		if ( isDefined( result ) ) {
+		if (isDefined(result)) {
 			// Unwrap the value now in case it was really actually null for real
-			return new ScopeSearchResult( CGIScope, Struct.unWrapNull( result ), key );
+			return new ScopeSearchResult(CGIScope, Struct.unWrapNull(result), key);
 		}
 
-		result = URLScope.getRaw( key );
+		result = URLScope.getRaw(key);
 		// Null means not found
-		if ( isDefined( result ) ) {
+		if (isDefined(result)) {
 			// Unwrap the value now in case it was really actually null for real
-			return new ScopeSearchResult( URLScope, Struct.unWrapNull( result ), key );
+			return new ScopeSearchResult(URLScope, Struct.unWrapNull(result), key);
 		}
 
-		result = formScope.getRaw( key );
+		result = formScope.getRaw(key);
 		// Null means not found
-		if ( isDefined( result ) ) {
+		if (isDefined(result)) {
 			// Unwrap the value now in case it was really actually null for real
-			return new ScopeSearchResult( formScope, Struct.unWrapNull( result ), key );
+			return new ScopeSearchResult(formScope, Struct.unWrapNull(result), key);
 		}
 
-		return super.scopeFind( key, defaultScope );
+		return super.scopeFind(key, defaultScope);
 	}
 
 	/**
@@ -295,36 +296,35 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * @return The requested scope
 	 */
 	@Override
-	public IScope getScope( Key name ) throws ScopeNotFoundException {
+	public IScope getScope(Key name) throws ScopeNotFoundException {
 
-		if ( name.equals( requestScope.getName() ) ) {
+		if (name.equals(requestScope.getName())) {
 			return requestScope;
 		}
 
-		if ( name.equals( URLScope.getName() ) ) {
+		if (name.equals(URLScope.getName())) {
 			return URLScope;
 		}
 
-		if ( name.equals( formScope.getName() ) ) {
+		if (name.equals(formScope.getName())) {
 			return formScope;
 		}
 
-		if ( name.equals( CGIScope.getName() ) ) {
+		if (name.equals(CGIScope.getName())) {
 			return CGIScope;
 		}
 
-		if ( name.equals( cookieScope.getName() ) ) {
+		if (name.equals(cookieScope.getName())) {
 			return cookieScope;
 		}
 
-		if ( parent != null ) {
-			return parent.getScope( name );
+		if (parent != null) {
+			return parent.getScope(name);
 		}
 
 		// Not found anywhere
 		throw new ScopeNotFoundException(
-		    String.format( "The requested scope name [%s] was not located in any context", name.getName() )
-		);
+				String.format("The requested scope name [%s] was not located in any context", name.getName()));
 
 	}
 
@@ -335,25 +335,25 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * @return The requested scope
 	 */
 	@Override
-	public IScope getScopeNearby( Key name, boolean shallow ) throws ScopeNotFoundException {
+	public IScope getScopeNearby(Key name, boolean shallow) throws ScopeNotFoundException {
 		// Check the scopes I know about
-		if ( name.equals( variablesScope.getName() ) ) {
+		if (name.equals(variablesScope.getName())) {
 			return variablesScope;
 		}
 
-		if ( shallow ) {
+		if (shallow) {
 			return null;
 		}
 
-		return getScope( name );
+		return getScope(name);
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	@Override
-	public void registerUDF( UDF udf, boolean override ) {
-		registerUDF( variablesScope, udf, override );
+	public void registerUDF(UDF udf, boolean override) {
+		registerUDF(variablesScope, udf, override);
 	}
 
 	/**
@@ -374,30 +374,30 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * @return This context
 	 */
 	@Override
-	public IBoxContext flushBuffer( boolean force ) {
-		if ( !canOutput() && !force ) {
+	public IBoxContext flushBuffer(boolean force) {
+		if (!canOutput() && !force) {
 			return this;
 		}
 		String output = "";
 		// If there are extra buffers registered, we ignore flush requests since someone
 		// out there is wanting to capture our buffer instead.
-		if ( buffers.size() == 1 ) {
+		if (buffers.size() == 1) {
 			StringBuffer buffer = getBuffer();
-			synchronized ( buffer ) {
+			synchronized (buffer) {
 				output = buffer.toString();
 				clearBuffer();
 			}
 
-		} else if ( force ) {
-			for ( StringBuffer buf : buffers ) {
-				synchronized ( buf ) {
-					output = output.concat( buf.toString() );
-					buf.setLength( 0 );
+		} else if (force) {
+			for (StringBuffer buf : buffers) {
+				synchronized (buf) {
+					output = output.concat(buf.toString());
+					buf.setLength(0);
 				}
 			}
 		}
-		if ( !output.isEmpty() ) {
-			httpExchange.getResponseWriter().write( output );
+		if (!output.isEmpty()) {
+			httpExchange.getResponseWriter().write(output);
 			httpExchange.flushResponseBuffer();
 		}
 		return this;
@@ -419,11 +419,11 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 */
 	public Object getRequestBody() {
 		// TODO: rework this to deal with binary and text request bodies
-		if ( requestBody != null ) {
+		if (requestBody != null) {
 			return requestBody;
 		}
-		synchronized ( httpExchange ) {
-			if ( requestBody != null ) {
+		synchronized (httpExchange) {
+			if (requestBody != null) {
 				return requestBody;
 			}
 			requestBody = httpExchange.getRequestBody();
@@ -434,7 +434,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 
 	public IStruct getConfig() {
 		var config = super.getConfig();
-		config.getAsStruct( Key.mappings ).put( "/", webRoot );
+		config.getAsStruct(Key.mappings).put("/", webRoot);
 		return config;
 	}
 
@@ -456,16 +456,18 @@ public class WebRequestBoxContext extends RequestBoxContext {
 
 	/**
 	 * Check if whitespace compression is enabled.
-	 * Return true if the content-type is HTML and the compression is enabled in the config
+	 * Return true if the content-type is HTML and the compression is enabled in the
+	 * config
 	 */
 	public boolean isWhitespaceCompressionEnabled() {
 		IStruct config = getConfig();
 		// If the global setting is disabled, return false
-		if ( !BooleanCaster.cast( config.getOrDefault( Key.whitespaceCompressionEnabled, true ) ) ) {
+		if (!BooleanCaster.cast(config.getOrDefault(Key.whitespaceCompressionEnabled, true))) {
 			return false;
 		}
 		// If the response is HTML, return true
-		if ( httpExchange.getResponseHeader( "Content-Type" ).startsWith( "text/html" ) ) {
+		String contentTypeHeader = httpExchange.getResponseHeader("Content-Type");
+		if (contentTypeHeader != null && contentTypeHeader.startsWith("text/html")) {
 			return true;
 		}
 		// It's another content type like binary or JSON, etc

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -45,7 +45,7 @@ import ortus.boxlang.web.scopes.URLScope;
  */
 public class WebRequestBoxContext extends RequestBoxContext {
 
-	private static BoxRuntime runtime = BoxRuntime.getInstance();
+	private static BoxRuntime	runtime			= BoxRuntime.getInstance();
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -56,49 +56,49 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	/**
 	 * The variables scope
 	 */
-	protected IScope variablesScope = new VariablesScope();
+	protected IScope			variablesScope	= new VariablesScope();
 
 	/**
 	 * The request scope
 	 */
-	protected IScope requestScope;
+	protected IScope			requestScope;
 
 	/**
 	 * The URL scope
 	 */
-	protected IScope URLScope;
+	protected IScope			URLScope;
 
 	/**
 	 * The form scope
 	 */
-	protected IScope formScope;
+	protected IScope			formScope;
 
 	/**
 	 * The CGI scope
 	 */
-	protected IScope CGIScope;
+	protected IScope			CGIScope;
 
 	/**
 	 * The cookie scope
 	 */
-	protected IScope cookieScope;
+	protected IScope			cookieScope;
 
-	protected IBoxHTTPExchange httpExchange;
+	protected IBoxHTTPExchange	httpExchange;
 
 	/**
 	 * The request body can only be read once, so we cache it here
 	 */
-	protected Object requestBody = null;
+	protected Object			requestBody		= null;
 
 	/**
 	 * The web root for this request
 	 */
-	protected String webRoot;
+	protected String			webRoot;
 
 	/**
 	 * The session ID for this request
 	 */
-	protected Key sessionID = null;
+	protected Key				sessionID		= null;
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -112,16 +112,16 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 *
 	 * @param parent The parent context
 	 */
-	public WebRequestBoxContext(IBoxContext parent, IBoxHTTPExchange httpExchange, String webRoot, URI template) {
-		super(parent);
-		httpExchange.setWebContext(this);
-		this.httpExchange = httpExchange;
-		this.webRoot = webRoot;
-		URLScope = new URLScope(httpExchange);
-		formScope = new FormScope(httpExchange);
-		CGIScope = new CGIScope(httpExchange);
-		cookieScope = new CookieScope(httpExchange);
-		requestScope = new RequestScope(httpExchange);
+	public WebRequestBoxContext( IBoxContext parent, IBoxHTTPExchange httpExchange, String webRoot, URI template ) {
+		super( parent );
+		httpExchange.setWebContext( this );
+		this.httpExchange	= httpExchange;
+		this.webRoot		= webRoot;
+		URLScope			= new URLScope( httpExchange );
+		formScope			= new FormScope( httpExchange );
+		CGIScope			= new CGIScope( httpExchange );
+		cookieScope			= new CookieScope( httpExchange );
+		requestScope		= new RequestScope( httpExchange );
 	}
 
 	/**
@@ -130,8 +130,8 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 *
 	 * @param parent The parent context
 	 */
-	public WebRequestBoxContext(IBoxContext parent, IBoxHTTPExchange exchange, String webRoot) {
-		this(parent, exchange, webRoot, null);
+	public WebRequestBoxContext( IBoxContext parent, IBoxHTTPExchange exchange, String webRoot ) {
+		this( parent, exchange, webRoot, null );
 	}
 
 	/**
@@ -147,23 +147,23 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 */
 	public Key getSessionID() {
 		// Only look if this is the first time for this request
-		if (this.sessionID == null) {
+		if ( this.sessionID == null ) {
 			// Double check lock pattern for threading safety
-			synchronized (this) {
+			synchronized ( this ) {
 				// double check...
-				if (this.sessionID == null) {
+				if ( this.sessionID == null ) {
 					// Look in a request cookie
 					// TODO: make cookie name configurable
-					BoxCookie sessionCookie = httpExchange.getRequestCookie("jsessionid");
-					if (sessionCookie != null) {
-						this.sessionID = Key.of(sessionCookie.getValue());
+					BoxCookie sessionCookie = httpExchange.getRequestCookie( "jsessionid" );
+					if ( sessionCookie != null ) {
+						this.sessionID = Key.of( sessionCookie.getValue() );
 					} else {
 						// Otherwise generate a new one
-						this.sessionID = Key.of(UUID.randomUUID().toString());
+						this.sessionID = Key.of( UUID.randomUUID().toString() );
 						// TODO: secure, domain, etc
 						httpExchange.addResponseCookie(
-								new BoxCookie("jsessionid", sessionID.getName())
-										.setPath("/"));
+						    new BoxCookie( "jsessionid", sessionID.getName() )
+						        .setPath( "/" ) );
 					}
 				}
 			}
@@ -176,10 +176,10 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * Invalidate a session
 	 */
 	public void resetSession() {
-		synchronized (this) {
+		synchronized ( this ) {
 			this.sessionID = null;
-			httpExchange.addResponseCookie(new BoxCookie("jsessionid", null));
-			getApplicationListener().invalidateSession(getSessionID());
+			httpExchange.addResponseCookie( new BoxCookie( "jsessionid", null ) );
+			getApplicationListener().invalidateSession( getSessionID() );
 		}
 	}
 
@@ -187,19 +187,19 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * @inheritDoc
 	 */
 	@Override
-	public IStruct getVisibleScopes(IStruct scopes, boolean nearby, boolean shallow) {
-		if (hasParent() && !shallow) {
-			getParent().getVisibleScopes(scopes, false, false);
+	public IStruct getVisibleScopes( IStruct scopes, boolean nearby, boolean shallow ) {
+		if ( hasParent() && !shallow ) {
+			getParent().getVisibleScopes( scopes, false, false );
 		}
-		scopes.getAsStruct(Key.contextual).put(ortus.boxlang.web.scopes.URLScope.name, URLScope);
-		scopes.getAsStruct(Key.contextual).put(FormScope.name, formScope);
-		scopes.getAsStruct(Key.contextual).put(ortus.boxlang.web.scopes.CGIScope.name, CGIScope);
-		scopes.getAsStruct(Key.contextual).put(CookieScope.name, cookieScope);
-		scopes.getAsStruct(Key.contextual).put(RequestScope.name, requestScope);
-		if (nearby) {
-			scopes.getAsStruct(Key.contextual).put(VariablesScope.name, variablesScope);
+		scopes.getAsStruct( Key.contextual ).put( ortus.boxlang.web.scopes.URLScope.name, URLScope );
+		scopes.getAsStruct( Key.contextual ).put( FormScope.name, formScope );
+		scopes.getAsStruct( Key.contextual ).put( ortus.boxlang.web.scopes.CGIScope.name, CGIScope );
+		scopes.getAsStruct( Key.contextual ).put( CookieScope.name, cookieScope );
+		scopes.getAsStruct( Key.contextual ).put( RequestScope.name, requestScope );
+		if ( nearby ) {
+			scopes.getAsStruct( Key.contextual ).put( VariablesScope.name, variablesScope );
 		}
-		return super.getVisibleScopes(scopes, nearby, shallow);
+		return super.getVisibleScopes( scopes, nearby, shallow );
 	}
 
 	/**
@@ -213,27 +213,27 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 *
 	 */
 	@Override
-	public ScopeSearchResult scopeFindNearby(Key key, IScope defaultScope, boolean shallow) {
+	public ScopeSearchResult scopeFindNearby( Key key, IScope defaultScope, boolean shallow ) {
 
 		// In query loop?
-		var querySearch = queryFindNearby(key);
-		if (querySearch != null) {
+		var querySearch = queryFindNearby( key );
+		if ( querySearch != null ) {
 			return querySearch;
 		}
 
 		// In Variables scope? (thread-safe lookup and get)
-		Object result = variablesScope.getRaw(key);
+		Object result = variablesScope.getRaw( key );
 		// Null means not found
-		if (isDefined(result)) {
+		if ( isDefined( result ) ) {
 			// Unwrap the value now in case it was really actually null for real
-			return new ScopeSearchResult(variablesScope, Struct.unWrapNull(result), key);
+			return new ScopeSearchResult( variablesScope, Struct.unWrapNull( result ), key );
 		}
 
-		if (shallow) {
+		if ( shallow ) {
 			return null;
 		}
 
-		return scopeFind(key, defaultScope);
+		return scopeFind( key, defaultScope );
 	}
 
 	/**
@@ -248,45 +248,45 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 *
 	 */
 	@Override
-	public ScopeSearchResult scopeFind(Key key, IScope defaultScope) {
+	public ScopeSearchResult scopeFind( Key key, IScope defaultScope ) {
 
-		if (key.equals(requestScope.getName())) {
-			return new ScopeSearchResult(requestScope, requestScope, key, true);
+		if ( key.equals( requestScope.getName() ) ) {
+			return new ScopeSearchResult( requestScope, requestScope, key, true );
 		}
-		if (key.equals(CGIScope.getName())) {
-			return new ScopeSearchResult(CGIScope, CGIScope, key, true);
+		if ( key.equals( CGIScope.getName() ) ) {
+			return new ScopeSearchResult( CGIScope, CGIScope, key, true );
 		}
-		if (key.equals(URLScope.getName())) {
-			return new ScopeSearchResult(URLScope, URLScope, key, true);
+		if ( key.equals( URLScope.getName() ) ) {
+			return new ScopeSearchResult( URLScope, URLScope, key, true );
 		}
-		if (key.equals(formScope.getName())) {
-			return new ScopeSearchResult(formScope, formScope, key, true);
+		if ( key.equals( formScope.getName() ) ) {
+			return new ScopeSearchResult( formScope, formScope, key, true );
 		}
-		if (key.equals(cookieScope.getName())) {
-			return new ScopeSearchResult(cookieScope, cookieScope, key, true);
+		if ( key.equals( cookieScope.getName() ) ) {
+			return new ScopeSearchResult( cookieScope, cookieScope, key, true );
 		}
-		Object result = CGIScope.getRaw(key);
+		Object result = CGIScope.getRaw( key );
 		// Null means not found
-		if (isDefined(result)) {
+		if ( isDefined( result ) ) {
 			// Unwrap the value now in case it was really actually null for real
-			return new ScopeSearchResult(CGIScope, Struct.unWrapNull(result), key);
+			return new ScopeSearchResult( CGIScope, Struct.unWrapNull( result ), key );
 		}
 
-		result = URLScope.getRaw(key);
+		result = URLScope.getRaw( key );
 		// Null means not found
-		if (isDefined(result)) {
+		if ( isDefined( result ) ) {
 			// Unwrap the value now in case it was really actually null for real
-			return new ScopeSearchResult(URLScope, Struct.unWrapNull(result), key);
+			return new ScopeSearchResult( URLScope, Struct.unWrapNull( result ), key );
 		}
 
-		result = formScope.getRaw(key);
+		result = formScope.getRaw( key );
 		// Null means not found
-		if (isDefined(result)) {
+		if ( isDefined( result ) ) {
 			// Unwrap the value now in case it was really actually null for real
-			return new ScopeSearchResult(formScope, Struct.unWrapNull(result), key);
+			return new ScopeSearchResult( formScope, Struct.unWrapNull( result ), key );
 		}
 
-		return super.scopeFind(key, defaultScope);
+		return super.scopeFind( key, defaultScope );
 	}
 
 	/**
@@ -296,35 +296,35 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * @return The requested scope
 	 */
 	@Override
-	public IScope getScope(Key name) throws ScopeNotFoundException {
+	public IScope getScope( Key name ) throws ScopeNotFoundException {
 
-		if (name.equals(requestScope.getName())) {
+		if ( name.equals( requestScope.getName() ) ) {
 			return requestScope;
 		}
 
-		if (name.equals(URLScope.getName())) {
+		if ( name.equals( URLScope.getName() ) ) {
 			return URLScope;
 		}
 
-		if (name.equals(formScope.getName())) {
+		if ( name.equals( formScope.getName() ) ) {
 			return formScope;
 		}
 
-		if (name.equals(CGIScope.getName())) {
+		if ( name.equals( CGIScope.getName() ) ) {
 			return CGIScope;
 		}
 
-		if (name.equals(cookieScope.getName())) {
+		if ( name.equals( cookieScope.getName() ) ) {
 			return cookieScope;
 		}
 
-		if (parent != null) {
-			return parent.getScope(name);
+		if ( parent != null ) {
+			return parent.getScope( name );
 		}
 
 		// Not found anywhere
 		throw new ScopeNotFoundException(
-				String.format("The requested scope name [%s] was not located in any context", name.getName()));
+		    String.format( "The requested scope name [%s] was not located in any context", name.getName() ) );
 
 	}
 
@@ -335,25 +335,25 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * @return The requested scope
 	 */
 	@Override
-	public IScope getScopeNearby(Key name, boolean shallow) throws ScopeNotFoundException {
+	public IScope getScopeNearby( Key name, boolean shallow ) throws ScopeNotFoundException {
 		// Check the scopes I know about
-		if (name.equals(variablesScope.getName())) {
+		if ( name.equals( variablesScope.getName() ) ) {
 			return variablesScope;
 		}
 
-		if (shallow) {
+		if ( shallow ) {
 			return null;
 		}
 
-		return getScope(name);
+		return getScope( name );
 	}
 
 	/**
 	 * @inheritDoc
 	 */
 	@Override
-	public void registerUDF(UDF udf, boolean override) {
-		registerUDF(variablesScope, udf, override);
+	public void registerUDF( UDF udf, boolean override ) {
+		registerUDF( variablesScope, udf, override );
 	}
 
 	/**
@@ -374,30 +374,30 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 * @return This context
 	 */
 	@Override
-	public IBoxContext flushBuffer(boolean force) {
-		if (!canOutput() && !force) {
+	public IBoxContext flushBuffer( boolean force ) {
+		if ( !canOutput() && !force ) {
 			return this;
 		}
 		String output = "";
 		// If there are extra buffers registered, we ignore flush requests since someone
 		// out there is wanting to capture our buffer instead.
-		if (buffers.size() == 1) {
+		if ( buffers.size() == 1 ) {
 			StringBuffer buffer = getBuffer();
-			synchronized (buffer) {
+			synchronized ( buffer ) {
 				output = buffer.toString();
 				clearBuffer();
 			}
 
-		} else if (force) {
-			for (StringBuffer buf : buffers) {
-				synchronized (buf) {
-					output = output.concat(buf.toString());
-					buf.setLength(0);
+		} else if ( force ) {
+			for ( StringBuffer buf : buffers ) {
+				synchronized ( buf ) {
+					output = output.concat( buf.toString() );
+					buf.setLength( 0 );
 				}
 			}
 		}
-		if (!output.isEmpty()) {
-			httpExchange.getResponseWriter().write(output);
+		if ( !output.isEmpty() ) {
+			httpExchange.getResponseWriter().write( output );
 			httpExchange.flushResponseBuffer();
 		}
 		return this;
@@ -419,11 +419,11 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 */
 	public Object getRequestBody() {
 		// TODO: rework this to deal with binary and text request bodies
-		if (requestBody != null) {
+		if ( requestBody != null ) {
 			return requestBody;
 		}
-		synchronized (httpExchange) {
-			if (requestBody != null) {
+		synchronized ( httpExchange ) {
+			if ( requestBody != null ) {
 				return requestBody;
 			}
 			requestBody = httpExchange.getRequestBody();
@@ -434,7 +434,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 
 	public IStruct getConfig() {
 		var config = super.getConfig();
-		config.getAsStruct(Key.mappings).put("/", webRoot);
+		config.getAsStruct( Key.mappings ).put( "/", webRoot );
 		return config;
 	}
 
@@ -462,12 +462,12 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	public boolean isWhitespaceCompressionEnabled() {
 		IStruct config = getConfig();
 		// If the global setting is disabled, return false
-		if (!BooleanCaster.cast(config.getOrDefault(Key.whitespaceCompressionEnabled, true))) {
+		if ( !BooleanCaster.cast( config.getOrDefault( Key.whitespaceCompressionEnabled, true ) ) ) {
 			return false;
 		}
 		// If the response is HTML, return true
-		String contentTypeHeader = httpExchange.getResponseHeader("Content-Type");
-		if (contentTypeHeader != null && contentTypeHeader.startsWith("text/html")) {
+		String contentTypeHeader = httpExchange.getResponseHeader( "Content-Type" );
+		if ( contentTypeHeader != null && contentTypeHeader.startsWith( "text/html" ) ) {
 			return true;
 		}
 		// It's another content type like binary or JSON, etc

--- a/src/main/java/ortus/boxlang/web/scopes/CGIScope.java
+++ b/src/main/java/ortus/boxlang/web/scopes/CGIScope.java
@@ -299,4 +299,13 @@ public class CGIScope extends BaseScope {
 	private Object defaultNullToString( Object value ) {
 		return value == null ? "" : value;
 	}
+
+	/**
+	 * Returns a {@link Set} view of the keys contained in this map.
+	 */
+	@Override
+	public Set<Key> keySet() {
+		return knownKeys;
+	}
+
 }


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta23

### Improvement

[BL-769](https://ortussolutions.atlassian.net/browse/BL-769) dump default to console output when in scripting context

[BL-770](https://ortussolutions.atlassian.net/browse/BL-770) avoid date parsing in len\(\) BIF

### Bug

[BL-761](https://ortussolutions.atlassian.net/browse/BL-761) Error when using abort in cfdump tag

[BL-763](https://ortussolutions.atlassian.net/browse/BL-763) whitespace management handle no content-type response header set yet

[BL-765](https://ortussolutions.atlassian.net/browse/BL-765) Difference of behaviour for handing arguments passed by position vs named

[BL-772](https://ortussolutions.atlassian.net/browse/BL-772) dsn key for jdbc drivers was not being used correctly as per cfconfig and replacements and producing invalid jdbc urls

[BL-774](https://ortussolutions.atlassian.net/browse/BL-774) Improve DateTimeCaster/DateTime instantiation performance with Strings

[BL-775](https://ortussolutions.atlassian.net/browse/BL-775) onSessionStart\(\) can cause endless recursion

[BL-776](https://ortussolutions.atlassian.net/browse/BL-776) debugmode flag in boxlang.json doesn't seem to be getting used

[BL-778](https://ortussolutions.atlassian.net/browse/BL-778) reconfigure debug mode doesn't work in a servlet

[BL-779](https://ortussolutions.atlassian.net/browse/BL-779) Logging interceptor is recreating appenders and loggers and discarding them on each log message, this is inefficient and a bottleneck under stress

[BL-780](https://ortussolutions.atlassian.net/browse/BL-780) writelog and log components where missing the \`application\` boolean argument

### New Feature

[BL-750](https://ortussolutions.atlassian.net/browse/BL-750) Component in BX for modules

[BL-768](https://ortussolutions.atlassian.net/browse/BL-768) ModuleService check the "boxlang" version to make sure the module is compatible or not

[BL-771](https://ortussolutions.atlassian.net/browse/BL-771) Generic JDBC Driver add a default URL delimiter, since some DBs are different

[BL-777](https://ortussolutions.atlassian.net/browse/BL-777) new getSemver\(\) bif to build or parse semvers and return a Semver object

### Story

[BL-116](https://ortussolutions.atlassian.net/browse/BL-116) Implement unfinished query options

[BL-769]: https://ortussolutions.atlassian.net/browse/BL-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-770]: https://ortussolutions.atlassian.net/browse/BL-770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-761]: https://ortussolutions.atlassian.net/browse/BL-761?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-763]: https://ortussolutions.atlassian.net/browse/BL-763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-765]: https://ortussolutions.atlassian.net/browse/BL-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-772]: https://ortussolutions.atlassian.net/browse/BL-772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-774]: https://ortussolutions.atlassian.net/browse/BL-774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-775]: https://ortussolutions.atlassian.net/browse/BL-775?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-776]: https://ortussolutions.atlassian.net/browse/BL-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ