### PR TITLE
1.0.0-Beta25

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
    compileOnly files( 'src/test/resources/libs/boxlang-' + boxlangVersion + '-all.jar' )
 
 	// For HTML Parsing
-	implementation 'org.jsoup:jsoup:1.18.1'
+	implementation 'org.jsoup:jsoup:1.18.3'
 
     // Testing Dependencies
 	testImplementation files( 'src/test/resources/libs/boxlang-' + boxlangVersion + '-all.jar' )

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta23] - 2024-11-23
+
 ## [1.0.0-beta22] - 2024-11-15
 
 ## [1.0.0-beta21] - 2024-11-01
@@ -87,7 +89,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.0.0-beta1]: https://github.com/ortus-boxlang/boxlang-web-support/compare/36688119b6956a927323667c1672e2ac7bab540e...v1.0.0-beta1
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta22...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta23...HEAD
+
+[1.0.0-beta23]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta15...v1.0.0-beta23
 
 [1.0.0-beta22]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta15...v1.0.0-beta22
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-beta24] - 2024-12-02
+
 ## [1.0.0-beta23] - 2024-11-23
 
 ## [1.0.0-beta22] - 2024-11-15
@@ -89,7 +91,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [1.0.0-beta1]: https://github.com/ortus-boxlang/boxlang-web-support/compare/36688119b6956a927323667c1672e2ac7bab540e...v1.0.0-beta1
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta23...HEAD
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta24...HEAD
+
+[1.0.0-beta24]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta15...v1.0.0-beta24
 
 [1.0.0-beta23]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0-beta15...v1.0.0-beta23
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Sat Nov 23 12:33:20 UTC 2024
-boxlangVersion=1.0.0-beta24
+#Mon Dec 02 11:35:51 UTC 2024
+boxlangVersion=1.0.0-beta25
 jdkVersion=21
-version=1.0.0-beta24
+version=1.0.0-beta25
 group=ortus.boxlang

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Fri Nov 15 22:15:54 UTC 2024
-boxlangVersion=1.0.0-beta23
+#Sat Nov 23 12:33:20 UTC 2024
+boxlangVersion=1.0.0-beta24
 jdkVersion=21
-version=1.0.0-beta23
+version=1.0.0-beta24
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -18,6 +18,8 @@
 package ortus.boxlang.web.context;
 
 import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Date;
 import java.util.UUID;
 
@@ -191,7 +193,12 @@ public class WebRequestBoxContext extends RequestBoxContext {
 					}
 
 					// Keepalive the session
-					sessionCookie.setExpires( Date.from( sessionCookieSettings.getAsDateTime( Key.timeout ).toInstant() ) );
+					Object expiration = sessionCookieSettings.get( Key.timeout );
+					if ( expiration instanceof DateTime expireDateTime ) {
+						sessionCookie.setExpires( Date.from( expireDateTime.toInstant() ) );
+					} else if ( expiration instanceof Duration expireDuration ) {
+						sessionCookie.setExpires( Date.from( Instant.now().plus( expireDuration ) ) );
+					}
 					httpExchange.addResponseCookie( sessionCookie );
 				}
 			}

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -191,7 +191,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 					}
 
 					// Keepalive the session
-					sessionCookie.setExpires( Date.from( sessionCookieSettings.getAsDateTime( Key.expires ).toInstant() ) );
+					sessionCookie.setExpires( Date.from( sessionCookieSettings.getAsDateTime( Key.timeout ).toInstant() ) );
 					httpExchange.addResponseCookie( sessionCookie );
 				}
 			}

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -18,6 +18,7 @@
 package ortus.boxlang.web.context;
 
 import java.net.URI;
+import java.util.Date;
 import java.util.UUID;
 
 import ortus.boxlang.runtime.BoxRuntime;
@@ -27,6 +28,7 @@ import ortus.boxlang.runtime.dynamic.casters.BooleanCaster;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.DateTime;
 import ortus.boxlang.runtime.types.IStruct;
 import ortus.boxlang.runtime.types.Struct;
 import ortus.boxlang.runtime.types.UDF;
@@ -38,6 +40,7 @@ import ortus.boxlang.web.scopes.CookieScope;
 import ortus.boxlang.web.scopes.FormScope;
 import ortus.boxlang.web.scopes.RequestScope;
 import ortus.boxlang.web.scopes.URLScope;
+import ortus.boxlang.web.util.KeyDictionary;
 
 /**
  * This context represents the context of a web/HTTP site in BoxLang
@@ -45,7 +48,7 @@ import ortus.boxlang.web.scopes.URLScope;
  */
 public class WebRequestBoxContext extends RequestBoxContext {
 
-	private static BoxRuntime	runtime			= BoxRuntime.getInstance();
+	private static BoxRuntime	runtime					= BoxRuntime.getInstance();
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -56,7 +59,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	/**
 	 * The variables scope
 	 */
-	protected IScope			variablesScope	= new VariablesScope();
+	protected IScope			variablesScope			= new VariablesScope();
 
 	/**
 	 * The request scope
@@ -88,7 +91,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	/**
 	 * The request body can only be read once, so we cache it here
 	 */
-	protected Object			requestBody		= null;
+	protected Object			requestBody				= null;
 
 	/**
 	 * The web root for this request
@@ -98,7 +101,18 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	/**
 	 * The session ID for this request
 	 */
-	protected Key				sessionID		= null;
+	protected Key				sessionID				= null;
+
+	protected IStruct			appSettings;
+
+	protected IStruct			sessionCookieDefaults	= Struct.of(
+	    Key._NAME, "jsessionid",
+	    KeyDictionary.secure, false,
+	    KeyDictionary.httpOnly, true,
+	    KeyDictionary.disableUpdate, false,
+	    Key.timeout, new DateTime().modify( "yyyy", 30l ),
+	    KeyDictionary.sameSiteMode, "Lax"
+	);
 
 	/**
 	 * --------------------------------------------------------------------------
@@ -122,6 +136,12 @@ public class WebRequestBoxContext extends RequestBoxContext {
 		CGIScope			= new CGIScope( httpExchange );
 		cookieScope			= new CookieScope( httpExchange );
 		requestScope		= new RequestScope( httpExchange );
+		appSettings			= getApplicationListener().getSettings();
+		appSettings.putIfAbsent( KeyDictionary.sessionCookie, new Struct() );
+		IStruct sessionCookieSettings = appSettings.getAsStruct( KeyDictionary.sessionCookie );
+		sessionCookieDefaults.entrySet().stream().forEach( entry -> {
+			sessionCookieSettings.putIfAbsent( entry.getKey(), entry.getValue() );
+		} );
 	}
 
 	/**
@@ -149,22 +169,30 @@ public class WebRequestBoxContext extends RequestBoxContext {
 		// Only look if this is the first time for this request
 		if ( this.sessionID == null ) {
 			// Double check lock pattern for threading safety
+			IStruct sessionCookieSettings = appSettings.getAsStruct( KeyDictionary.sessionCookie );
 			synchronized ( this ) {
 				// double check...
 				if ( this.sessionID == null ) {
-					// Look in a request cookie
-					// TODO: make cookie name configurable
-					BoxCookie sessionCookie = httpExchange.getRequestCookie( "jsessionid" );
+					// Check for existing request cookie
+					BoxCookie sessionCookie = httpExchange.getRequestCookie( sessionCookieDefaults.getAsString( Key._NAME ) );
 					if ( sessionCookie != null ) {
 						this.sessionID = Key.of( sessionCookie.getValue() );
 					} else {
 						// Otherwise generate a new one
-						this.sessionID = Key.of( UUID.randomUUID().toString() );
-						// TODO: secure, domain, etc
-						httpExchange.addResponseCookie(
-						    new BoxCookie( "jsessionid", sessionID.getName() )
-						        .setPath( "/" ) );
+						this.sessionID	= Key.of( UUID.randomUUID().toString() );
+
+						sessionCookie	= new BoxCookie( sessionCookieDefaults.getAsString( Key._NAME ), this.sessionID.getName() )
+						    .setPath( "/" )
+						    .setHttpOnly( sessionCookieSettings.getAsBoolean( KeyDictionary.httpOnly ) )
+						    .setSecure( sessionCookieSettings.getAsBoolean( Key.secure ) )
+						    .setDomain( sessionCookieSettings.getAsString( Key.domain ) )
+						    .setSameSiteMode( sessionCookieSettings.getAsString( KeyDictionary.sameSiteMode ) );
+
 					}
+
+					// Keepalive the session
+					sessionCookie.setExpires( Date.from( sessionCookieSettings.getAsDateTime( Key.expires ).toInstant() ) );
+					httpExchange.addResponseCookie( sessionCookie );
 				}
 			}
 		}
@@ -178,7 +206,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	public void resetSession() {
 		synchronized ( this ) {
 			this.sessionID = null;
-			httpExchange.addResponseCookie( new BoxCookie( "jsessionid", null ) );
+			httpExchange.addResponseCookie( new BoxCookie( sessionCookieDefaults.getAsString( Key._NAME ), null ) );
 			getApplicationListener().invalidateSession( getSessionID() );
 		}
 	}

--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -254,7 +254,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 *
 	 */
 	@Override
-	public ScopeSearchResult scopeFindNearby( Key key, IScope defaultScope, boolean shallow ) {
+	public ScopeSearchResult scopeFindNearby( Key key, IScope defaultScope, boolean shallow, boolean forAssign ) {
 
 		// In query loop?
 		var querySearch = queryFindNearby( key );
@@ -265,7 +265,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 		// In Variables scope? (thread-safe lookup and get)
 		Object result = variablesScope.getRaw( key );
 		// Null means not found
-		if ( isDefined( result ) ) {
+		if ( isDefined( result, forAssign ) ) {
 			// Unwrap the value now in case it was really actually null for real
 			return new ScopeSearchResult( variablesScope, Struct.unWrapNull( result ), key );
 		}
@@ -274,7 +274,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 			return null;
 		}
 
-		return scopeFind( key, defaultScope );
+		return scopeFind( key, defaultScope, forAssign );
 	}
 
 	/**
@@ -289,7 +289,7 @@ public class WebRequestBoxContext extends RequestBoxContext {
 	 *
 	 */
 	@Override
-	public ScopeSearchResult scopeFind( Key key, IScope defaultScope ) {
+	public ScopeSearchResult scopeFind( Key key, IScope defaultScope, boolean forAssign ) {
 
 		if ( key.equals( requestScope.getName() ) ) {
 			return new ScopeSearchResult( requestScope, requestScope, key, true );
@@ -308,26 +308,26 @@ public class WebRequestBoxContext extends RequestBoxContext {
 		}
 		Object result = CGIScope.getRaw( key );
 		// Null means not found
-		if ( isDefined( result ) ) {
+		if ( isDefined( result, forAssign ) ) {
 			// Unwrap the value now in case it was really actually null for real
 			return new ScopeSearchResult( CGIScope, Struct.unWrapNull( result ), key );
 		}
 
 		result = URLScope.getRaw( key );
 		// Null means not found
-		if ( isDefined( result ) ) {
+		if ( isDefined( result, forAssign ) ) {
 			// Unwrap the value now in case it was really actually null for real
 			return new ScopeSearchResult( URLScope, Struct.unWrapNull( result ), key );
 		}
 
 		result = formScope.getRaw( key );
 		// Null means not found
-		if ( isDefined( result ) ) {
+		if ( isDefined( result, forAssign ) ) {
 			// Unwrap the value now in case it was really actually null for real
 			return new ScopeSearchResult( formScope, Struct.unWrapNull( result ), key );
 		}
 
-		return super.scopeFind( key, defaultScope );
+		return super.scopeFind( key, defaultScope, forAssign );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/web/scopes/CookieScope.java
+++ b/src/main/java/ortus/boxlang/web/scopes/CookieScope.java
@@ -66,7 +66,9 @@ public class CookieScope extends BaseScope {
 	 */
 	@Override
 	public Object assign( IBoxContext context, Key key, Object value ) {
-		exchange.addResponseCookie( new BoxCookie( key.getName(), StringCaster.cast( value ) ) );
+		String castedValue = StringCaster.cast( value );
+		this.put( key, castedValue );
+		exchange.addResponseCookie( new BoxCookie( key.getName(), castedValue ) );
 		return value;
 	}
 }

--- a/src/main/java/ortus/boxlang/web/util/KeyDictionary.java
+++ b/src/main/java/ortus/boxlang/web/util/KeyDictionary.java
@@ -57,4 +57,12 @@ public class KeyDictionary {
 	public static final Key	timeCreated			= Key.of( "timeCreated" );
 	public static final Key	timeLastModified	= Key.of( "timeLastModified" );
 
+	// Session Cookie Settings
+	public static final Key	sessionCookie		= Key.of( "sessionCookie" );
+	public static final Key	secure				= Key.of( "secure" );
+	public static final Key	httpOnly			= Key.of( "httponly" );
+	public static final Key	sameSite			= Key.of( "sameSite" );
+	public static final Key	sameSiteMode		= Key.of( "sameSiteMode" );
+	public static final Key	disableUpdate		= Key.of( "disableUpdate" );
+
 }

--- a/src/test/java/ortus/boxlang/web/scopes/CookieScopeTest.java
+++ b/src/test/java/ortus/boxlang/web/scopes/CookieScopeTest.java
@@ -1,0 +1,88 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.web.scopes;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.web.context.WebRequestBoxContext;
+import ortus.boxlang.web.exchange.BoxCookie;
+import ortus.boxlang.web.exchange.IBoxHTTPExchange;
+
+public class CookieScopeTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				cookieScope;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		// Mock a connection
+		IBoxHTTPExchange mockExchange = Mockito.mock( IBoxHTTPExchange.class );
+		// Mock some objects which are used in the context
+		when( mockExchange.getRequestCookies() ).thenReturn( new BoxCookie[ 0 ] );
+		when( mockExchange.getRequestHeaderMap() ).thenReturn( new HashMap<String, String[]>() );
+		when( mockExchange.getResponseWriter() ).thenReturn( new PrintWriter( OutputStream.nullOutputStream() ) );
+		context		= new WebRequestBoxContext( instance.getRuntimeContext(), mockExchange, "/" );
+		variables	= context.getScopeNearby( VariablesScope.name );
+		cookieScope	= context.getScopeNearby( CookieScope.name );
+		cookieScope.clear();
+	}
+
+	@DisplayName( "It can get a value set earlier in the request" )
+	@Test
+	public void testSetAndGetInSameRequest() {
+		instance.executeSource(
+		    """
+		    checkA = cookie.keyExists( "foo" );
+		    cookie[ "foo" ] = "bar";
+		    checkB = cookie.keyExists( "foo" );
+		    result = cookie[ "foo" ];
+		    """,
+		    context );
+		Object checkA = variables.get( Key.of( "checkA" ) );
+		assertThat( ( Boolean ) checkA ).isFalse();
+		Object checkB = variables.get( Key.of( "checkB" ) );
+		assertThat( ( Boolean ) checkB ).isTrue();
+		assertThat( variables.getAsString( Key.of( "result" ) ) ).isEqualTo( "bar" );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/web/scopes/URLScopeTest.java
+++ b/src/test/java/ortus/boxlang/web/scopes/URLScopeTest.java
@@ -1,0 +1,84 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.web.scopes;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.web.context.WebRequestBoxContext;
+import ortus.boxlang.web.exchange.BoxCookie;
+import ortus.boxlang.web.exchange.IBoxHTTPExchange;
+
+public class URLScopeTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				urlScope;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		// Mock a connection
+		IBoxHTTPExchange mockExchange = Mockito.mock( IBoxHTTPExchange.class );
+		// Mock some objects which are used in the context
+		when( mockExchange.getRequestCookies() ).thenReturn( new BoxCookie[ 0 ] );
+		when( mockExchange.getRequestHeaderMap() ).thenReturn( new HashMap<String, String[]>() );
+		when( mockExchange.getResponseWriter() ).thenReturn( new PrintWriter( OutputStream.nullOutputStream() ) );
+		context		= new WebRequestBoxContext( instance.getRuntimeContext(), mockExchange, "/" );
+		urlScope	= context.getScopeNearby( URLScope.name );
+	}
+
+	@DisplayName( "It skips paraming a scope with values" )
+	@Test
+	public void testParamScopes() {
+		instance.executeSource(
+		    """
+		    url.result = "foo";
+		     	param url = {};
+		     """,
+		    context );
+		assertThat( urlScope.getAsString( result ) ).isEqualTo( "foo" );
+	}
+
+}


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta25

### Improvement

[BL-682](https://ortussolutions.atlassian.net/browse/BL-682) Method does not expect a return value

[BL-706](https://ortussolutions.atlassian.net/browse/BL-706) Add missing controls for session cookie

[BL-760](https://ortussolutions.atlassian.net/browse/BL-760) Add line number information to bytecode generated with ASM

[BL-766](https://ortussolutions.atlassian.net/browse/BL-766) Make ASM default/only stock boxpiler

[BL-784](https://ortussolutions.atlassian.net/browse/BL-784) Update all replaceAll\(\) as much as possible with pre-compiled patterns

[BL-787](https://ortussolutions.atlassian.net/browse/BL-787) Consolidate logging startups and configuration for servlets and non-servlets

[BL-788](https://ortussolutions.atlassian.net/browse/BL-788) Implement this.componentPaths for implicit mapping support

[BL-791](https://ortussolutions.atlassian.net/browse/BL-791) Support \`enabled\` in the boxlang.json for modules so they can be enabled or disabled and remove \`disabled\` double negative

[BL-809](https://ortussolutions.atlassian.net/browse/BL-809) Create Forms Module

[BL-812](https://ortussolutions.atlassian.net/browse/BL-812) Allow re-assignment of scope to a struct

[BL-822](https://ortussolutions.atlassian.net/browse/BL-822) prefix IClassRunnable methods to avoid collisions

[BL-830](https://ortussolutions.atlassian.net/browse/BL-830) Add defensive coding for module unloading in case they fail, so the runtime can gracefully shutdown.

[BL-831](https://ortussolutions.atlassian.net/browse/BL-831) struct collectors not returning IStruct but Struct

[BL-838](https://ortussolutions.atlassian.net/browse/BL-838) Add generic casting to all global service methods so method chaining is possible and cleaner syntax

[BL-839](https://ortussolutions.atlassian.net/browse/BL-839) Add a way for module class loaders to be able to delegate the location of certain parent classes to the parent ONLY, espeically for logging

### Bug

[BL-495](https://ortussolutions.atlassian.net/browse/BL-495) ACF arraySlice shorthand not supported

[BL-694](https://ortussolutions.atlassian.net/browse/BL-694) Fix tests that fail when using ASM

[BL-732](https://ortussolutions.atlassian.net/browse/BL-732) structsort with callback errors

[BL-742](https://ortussolutions.atlassian.net/browse/BL-742) Cleanup ASM tests that aren't passing

[BL-759](https://ortussolutions.atlassian.net/browse/BL-759) BoxLang debugger not able to read source maps from child VM

[BL-762](https://ortussolutions.atlassian.net/browse/BL-762) testbox fails running with asm flag

[BL-807](https://ortussolutions.atlassian.net/browse/BL-807) Java BoxPiler not correctly escaping all characters in string literals

[BL-813](https://ortussolutions.atlassian.net/browse/BL-813) local scope in thread context lookup not working

[BL-815](https://ortussolutions.atlassian.net/browse/BL-815) this.javaSettings is not accounting for mappings

[BL-817](https://ortussolutions.atlassian.net/browse/BL-817) Missing visibility on module service functions

[BL-818](https://ortussolutions.atlassian.net/browse/BL-818) Child with three levels of inheritance and no constructor on the child: init args calling super.init\(\) on grandparent with without args re-calls parent with empty args.

[BL-819](https://ortussolutions.atlassian.net/browse/BL-819) Cannot parse \`MMMM d yyyy HH:mm\` format in compat

[BL-820](https://ortussolutions.atlassian.net/browse/BL-820) DecodeBinary fails to Decode JWT prefix created by jwtCFML

[BL-821](https://ortussolutions.atlassian.net/browse/BL-821) this.timezone in Application.bx/cfc is not being promoted to request-level config setting

[BL-823](https://ortussolutions.atlassian.net/browse/BL-823) cfquery with final unquoted attribute value parse error

[BL-824](https://ortussolutions.atlassian.net/browse/BL-824) isJSON returns false negative when content contains Java Regex escape characters

[BL-825](https://ortussolutions.atlassian.net/browse/BL-825) DateConvert utc2Local and local2utc should be opinionated about zone when input contains no zone information

[BL-826](https://ortussolutions.atlassian.net/browse/BL-826) Coldbox CacheBox Reaping Tasks fail with NullPointerException

[BL-827](https://ortussolutions.atlassian.net/browse/BL-827) BOM not being stripped on fileRead, which causes issues parsing JSON files with

[BL-834](https://ortussolutions.atlassian.net/browse/BL-834) Dump Top Updates will not dump certain classes without a top argument, top shows as reached for subsequent dumps

[BL-835](https://ortussolutions.atlassian.net/browse/BL-835) Defensive coding when doing getConfig\(\) overrides in request box context from Application settings

[BL-836](https://ortussolutions.atlassian.net/browse/BL-836) When \`include\` is called within function, the UDFs in the mixin are not present. 

[BL-840](https://ortussolutions.atlassian.net/browse/BL-840) GetSystemSetting BIF is overriding Coldbox Env function and producing different results

[BL-841](https://ortussolutions.atlassian.net/browse/BL-841) Stack frames in console output are outputting HTML entities.

[BL-845](https://ortussolutions.atlassian.net/browse/BL-845) Transformers unecessary creating new script contexts for doing interface implementations, this was old code still left but broke all orm and context class loaders

### New Feature

[BL-94](https://ortussolutions.atlassian.net/browse/BL-94) Create query of queries support

[BL-121](https://ortussolutions.atlassian.net/browse/BL-121) createObject\(\) classloading arguments

[BL-310](https://ortussolutions.atlassian.net/browse/BL-310) Spread operator

[BL-311](https://ortussolutions.atlassian.net/browse/BL-311) Implement Array Destructuring assignment

[BL-699](https://ortussolutions.atlassian.net/browse/BL-699) Schedulers now have a startupTask\( task \) to dynamically startup a task by name or task object

[BL-749](https://ortussolutions.atlassian.net/browse/BL-749) Modularize the JavaBoxPiler so we can have ASM as core

[BL-794](https://ortussolutions.atlassian.net/browse/BL-794) Add json encoder for json based logging to all appenders and root

[BL-828](https://ortussolutions.atlassian.net/browse/BL-828) scheduler logs are now being reported

[BL-829](https://ortussolutions.atlassian.net/browse/BL-829) modules logs are now being used

[BL-832](https://ortussolutions.atlassian.net/browse/BL-832) onConfigurationLoad new event life-cycle for IServices

[BL-833](https://ortussolutions.atlassian.net/browse/BL-833) compat assignments need to "see" null variables

[BL-843](https://ortussolutions.atlassian.net/browse/BL-843) Move defaultCache to the caches section as default,  verify it exists, else create it anyways

[BL-846](https://ortussolutions.atlassian.net/browse/BL-846) New logging setting: statusPrinterOnLoad for much needed debuging of the logging configs

### Task

[BL-217](https://ortussolutions.atlassian.net/browse/BL-217) ColdBox Test Suite

[BL-220](https://ortussolutions.atlassian.net/browse/BL-220) Quick Test Suite

[BL-548](https://ortussolutions.atlassian.net/browse/BL-548) Parser performance and removing ambiguity 

[BL-767](https://ortussolutions.atlassian.net/browse/BL-767) CFcasts Suite

[BL-837](https://ortussolutions.atlassian.net/browse/BL-837) UnleashSDK Certification

### Story

[BL-237](https://ortussolutions.atlassian.net/browse/BL-237) Phase II : Update all the toAST\(\) methods to the new and consolidated approach

[BL-238](https://ortussolutions.atlassian.net/browse/BL-238) Phase III : Performance tests for phase I \+ II toolchains

[BL-239](https://ortussolutions.atlassian.net/browse/BL-239) Phase V : Create the QoQ SQL grammar, parser, and ast

[BL-682]: https://ortussolutions.atlassian.net/browse/BL-682?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-706]: https://ortussolutions.atlassian.net/browse/BL-706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-760]: https://ortussolutions.atlassian.net/browse/BL-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-766]: https://ortussolutions.atlassian.net/browse/BL-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-784]: https://ortussolutions.atlassian.net/browse/BL-784?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-787]: https://ortussolutions.atlassian.net/browse/BL-787?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-788]: https://ortussolutions.atlassian.net/browse/BL-788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-791]: https://ortussolutions.atlassian.net/browse/BL-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-809]: https://ortussolutions.atlassian.net/browse/BL-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ