### PR TITLE
beta26

### DIFF
--- a/src/test/java/ortus/boxlang/web/interceptors/WebRequestTest.java
+++ b/src/test/java/ortus/boxlang/web/interceptors/WebRequestTest.java
@@ -1,0 +1,38 @@
+package ortus.boxlang.web.interceptors;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.Struct;
+import ortus.boxlang.runtime.types.exceptions.AbortException;
+
+public class WebRequestTest extends ortus.boxlang.web.util.BaseWebTest {
+
+	static Key result = new Key( "result" );
+
+	@DisplayName( "Tests writeToBrowser with an abort directive" )
+	@Test
+	@Disabled
+	public void testWriteToBrowserAbort() {
+		variables.put(
+		    Key.of( "interceptData" ),
+		    Struct.of(
+		        Key.context, context,
+		        Key.content, "foo",
+		        Key.mimetype, "application/pdf",
+		        Key.of( "filename" ), "foo.txt",
+		        Key.reset, true,
+		        Key.abort, true
+		    )
+		);
+		assertThrows( AbortException.class, () -> runtime.executeSource(
+		    """
+		    getBoxRuntime().getInterceptorService().announce( "writeToBrowser", interceptData );
+		    """,
+		    context ) );
+	}
+}

--- a/src/test/java/ortus/boxlang/web/interceptors/WebRequestTest.java
+++ b/src/test/java/ortus/boxlang/web/interceptors/WebRequestTest.java
@@ -1,6 +1,6 @@
 package ortus.boxlang.web.interceptors;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,12 +26,17 @@ public class WebRequestTest extends ortus.boxlang.web.util.BaseWebTest {
 		        Key.abort, true
 		    )
 		);
-		assertDoesNotThrow( () -> runtime.executeSource(
-		    """
-		    getBoxRuntime().getInterceptorService().announce( "writeToBrowser", interceptData );
-		    """,
-		    context )
-		);
 
+		// @formatter:off
+		runtime.executeSource(
+		    """
+		      getBoxRuntime().getInterceptorService().announce( "writeToBrowser", interceptData )
+		   	  result = "foo"
+		      """,
+		    context );
+		// @formatter:on
+
+		// This should have never fired. We can't trap for an abort exception, because the executeSource traps it.
+		assertThat( variables.get( result ) ).isEqualTo( null );
 	}
 }

--- a/src/test/java/ortus/boxlang/web/interceptors/WebRequestTest.java
+++ b/src/test/java/ortus/boxlang/web/interceptors/WebRequestTest.java
@@ -1,13 +1,12 @@
 package ortus.boxlang.web.interceptors;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Struct;
-import ortus.boxlang.runtime.types.exceptions.AbortException;
 
 public class WebRequestTest extends ortus.boxlang.web.util.BaseWebTest {
 
@@ -21,16 +20,18 @@ public class WebRequestTest extends ortus.boxlang.web.util.BaseWebTest {
 		    Struct.of(
 		        Key.context, context,
 		        Key.content, "foo",
-		        Key.mimetype, "application/pdf",
+		        Key.mimetype, "text/plain",
 		        Key.of( "filename" ), "foo.txt",
 		        Key.reset, true,
 		        Key.abort, true
 		    )
 		);
-		assertThrows( AbortException.class, () -> runtime.executeSource(
+		assertDoesNotThrow( () -> runtime.executeSource(
 		    """
 		    getBoxRuntime().getInterceptorService().announce( "writeToBrowser", interceptData );
 		    """,
-		    context ) );
+		    context )
+		);
+
 	}
 }

--- a/src/test/java/ortus/boxlang/web/interceptors/WebRequestTest.java
+++ b/src/test/java/ortus/boxlang/web/interceptors/WebRequestTest.java
@@ -2,7 +2,6 @@ package ortus.boxlang.web.interceptors;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +15,6 @@ public class WebRequestTest extends ortus.boxlang.web.util.BaseWebTest {
 
 	@DisplayName( "Tests writeToBrowser with an abort directive" )
 	@Test
-	@Disabled
 	public void testWriteToBrowserAbort() {
 		variables.put(
 		    Key.of( "interceptData" ),

--- a/src/test/java/ortus/boxlang/web/util/BaseWebTest.java
+++ b/src/test/java/ortus/boxlang/web/util/BaseWebTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mockito;
 
 import ortus.boxlang.runtime.BoxRuntime;
 import ortus.boxlang.runtime.application.BaseApplicationListener;
-import ortus.boxlang.runtime.interop.DynamicObject;
 import ortus.boxlang.runtime.scopes.IScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.scopes.VariablesScope;
@@ -24,7 +23,6 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.web.context.WebRequestBoxContext;
 import ortus.boxlang.web.exchange.BoxCookie;
 import ortus.boxlang.web.exchange.IBoxHTTPExchange;
-import ortus.boxlang.web.interceptors.WebRequest;
 
 @TestInstance( TestInstance.Lifecycle.PER_CLASS )
 public class BaseWebTest {
@@ -42,10 +40,10 @@ public class BaseWebTest {
 		runtime = BoxRuntime.getInstance( true );
 
 		// We need to unregister in the setup because the runtime is a singleton in the cli request
-		runtime.getInterceptorService().unregister( DynamicObject.of( new WebRequest() ) );
+		// runtime.getInterceptorService().unregister( DynamicObject.of( new WebRequest() ) );
 
 		// Manually register our interceptor as it doesn't automatically get registered in the test environment
-		runtime.getInterceptorService().register( new WebRequest() );
+		// runtime.getInterceptorService().register( new WebRequest() );
 	}
 
 	@BeforeEach


### PR DESCRIPTION
# Release notes - BoxLang - 1.0.0-Beta26

### Improvement

[BL-838](https://ortussolutions.atlassian.net/browse/BL-838) Add generic casting to all global service methods so method chaining is possible and cleaner syntax

[BL-852](https://ortussolutions.atlassian.net/browse/BL-852) dump Lots of UI quality of life improvements: show length of strings, show full classes for some java integrations, and much more.

[BL-860](https://ortussolutions.atlassian.net/browse/BL-860) Update getMetaadata\(\) for dynamic proxies to leverage the class metadata instead of instances

[BL-865](https://ortussolutions.atlassian.net/browse/BL-865) CFTranspiler should not turn off accessors for persistent classes

[BL-866](https://ortussolutions.atlassian.net/browse/BL-866) Exception type matching check cause

[BL-919](https://ortussolutions.atlassian.net/browse/BL-919) Implement "Quick" algorithm for Hash BIF

[BL-920](https://ortussolutions.atlassian.net/browse/BL-920) Compat: CacheGet second argument is boolean for Lucee

[BL-926](https://ortussolutions.atlassian.net/browse/BL-926) ASM error in do/while with break

[BL-938](https://ortussolutions.atlassian.net/browse/BL-938) Update the getOrCreateSession\(\) to verify if the session has expired, and if so, rotate it.

[BL-939](https://ortussolutions.atlassian.net/browse/BL-939) Change generic tag-in-script syntax for Box Script to prefix with bx:

### Bug

[BL-495](https://ortussolutions.atlassian.net/browse/BL-495) ACF arraySlice shorthand not supported

[BL-621](https://ortussolutions.atlassian.net/browse/BL-621) Allow a productivity hack to add ability to pass queries to some struct functions by taking the first row and converting the query to a struct.

[BL-732](https://ortussolutions.atlassian.net/browse/BL-732) structsort with callback errors

[BL-758](https://ortussolutions.atlassian.net/browse/BL-758) QofQ shouldn't require global DSN

[BL-764](https://ortussolutions.atlassian.net/browse/BL-764) xmlsearch - invalid XPath 

[BL-801](https://ortussolutions.atlassian.net/browse/BL-801) ASM Failing test - fix bx:output transformer

[BL-802](https://ortussolutions.atlassian.net/browse/BL-802) ASM Failing test - fix abort exception

[BL-834](https://ortussolutions.atlassian.net/browse/BL-834) Dump Top Updates will not dump certain classes without a top argument, top shows as reached for subsequent dumps

[BL-847](https://ortussolutions.atlassian.net/browse/BL-847) BL GenericProxies cannot have java.lang.Object methods call on them

[BL-849](https://ortussolutions.atlassian.net/browse/BL-849) Class properties are merged from all inheritance levels in the metadata

[BL-850](https://ortussolutions.atlassian.net/browse/BL-850) Dumps are not in order of execution

[BL-851](https://ortussolutions.atlassian.net/browse/BL-851) Java List dumps are not working with top and are off by 1

[BL-854](https://ortussolutions.atlassian.net/browse/BL-854) Wirebox Block:  testbuildJavaClass Methods on Java objects cannot be called with named arguments when using invoke\(\)

[BL-855](https://ortussolutions.atlassian.net/browse/BL-855) Coercion for constructors from string to numbers are not working

[BL-856](https://ortussolutions.atlassian.net/browse/BL-856) Coercion from strings to numbers does not exist

[BL-857](https://ortussolutions.atlassian.net/browse/BL-857) isInstanceOf bif and keyword are not working on createObject\("java"\) proxies.  It gives a negative result

[BL-858](https://ortussolutions.atlassian.net/browse/BL-858) var scoping issues for bleeding scopes on class dump template

[BL-859](https://ortussolutions.atlassian.net/browse/BL-859) Calling getMetadata\(\) on an instance of dynamic object that has not yet been inited, shows the metadata of DynamicObject instead of the proxy class

[BL-861](https://ortussolutions.atlassian.net/browse/BL-861) ORM: getter setters are not enabled for persistent CFCs

[BL-863](https://ortussolutions.atlassian.net/browse/BL-863) ORM: writedump causes ClassInfo not found

[BL-864](https://ortussolutions.atlassian.net/browse/BL-864) ORM: entityLoad should only require entity name

[BL-867](https://ortussolutions.atlassian.net/browse/BL-867) Show the right exception type when invoking dynamic objects and there are exceptions from a caused by

[BL-868](https://ortussolutions.atlassian.net/browse/BL-868) caching does not handle quoted numbers or booleans in config

[BL-869](https://ortussolutions.atlassian.net/browse/BL-869) ORM: EntityLoad errors when using a filter

[BL-870](https://ortussolutions.atlassian.net/browse/BL-870) soft reference cannot  be stored directly in a struct

[BL-875](https://ortussolutions.atlassian.net/browse/BL-875) rework onSessionEnd to make sure the application exists when calling the listeners

[BL-877](https://ortussolutions.atlassian.net/browse/BL-877) Lucee allows params to be passed to cfquery tag via \`params\` attribute

[BL-879](https://ortussolutions.atlassian.net/browse/BL-879) IsNumeric\(\) returns true for "true" and "false"

[BL-880](https://ortussolutions.atlassian.net/browse/BL-880) QueryNew\(\) throws exception if row data array is empty

[BL-884](https://ortussolutions.atlassian.net/browse/BL-884) MSSQL throws error when executing certain queries if language is not English

[BL-885](https://ortussolutions.atlassian.net/browse/BL-885) Setting a dynamic variable name doesn't work

[BL-886](https://ortussolutions.atlassian.net/browse/BL-886) Can't cast \[now\] to a DateTime

[BL-887](https://ortussolutions.atlassian.net/browse/BL-887) cfloop step not implemented

[BL-888](https://ortussolutions.atlassian.net/browse/BL-888) allow "switch" as struct key name in CF script

[BL-889](https://ortussolutions.atlassian.net/browse/BL-889) The instance \[ortus.boxlang.runtime.types.exceptions.ParseException\] has no public field or inner class \[ERRORCODE\]

[BL-890](https://ortussolutions.atlassian.net/browse/BL-890) In function \[numberFormat\], argument \[number\] with a type of \[java.lang.Boolean\] does not match the declared type of \[number\]

[BL-891](https://ortussolutions.atlassian.net/browse/BL-891) Datasources created after module load take on custom DSN parameters defined in bx-mssql

[BL-892](https://ortussolutions.atlassian.net/browse/BL-892) cfqueryparam with list attribute causes "The index 2 is out of range"

[BL-893](https://ortussolutions.atlassian.net/browse/BL-893) Queryparam list=true is unsupported

[BL-894](https://ortussolutions.atlassian.net/browse/BL-894) Key in arguments scope gets lost

[BL-895](https://ortussolutions.atlassian.net/browse/BL-895) Allow "switch" to be used in dot access

[BL-896](https://ortussolutions.atlassian.net/browse/BL-896) Can't cast ts to a Number.

[BL-897](https://ortussolutions.atlassian.net/browse/BL-897) named query params not handled correctly

[BL-898](https://ortussolutions.atlassian.net/browse/BL-898) Account for placeholder text in comments and quoted strings in SQL

[BL-899](https://ortussolutions.atlassian.net/browse/BL-899) numberFormat is displaying a leading 0 when formatting integers < 10

[BL-901](https://ortussolutions.atlassian.net/browse/BL-901) Duplicate\(\) on CGI scope creates empty struct

[BL-902](https://ortussolutions.atlassian.net/browse/BL-902) CGI-Scope weirdness

[BL-903](https://ortussolutions.atlassian.net/browse/BL-903) MSSQL connection gets lost

[BL-904](https://ortussolutions.atlassian.net/browse/BL-904) Empty test fails when using ASM

[BL-905](https://ortussolutions.atlassian.net/browse/BL-905) MSSQL Query columns have wrong values

[BL-906](https://ortussolutions.atlassian.net/browse/BL-906) Using <bx:output> inside of <bx:catch> causes bxCatch scope to disappear

[BL-907](https://ortussolutions.atlassian.net/browse/BL-907) Array Loop with negative step doesn't work

[BL-909](https://ortussolutions.atlassian.net/browse/BL-909) Cannot invoke "ortus.boxlang.runtime.components.Component$BodyResult.isEarlyExit\(\)" because "bodyResult" is null

[BL-910](https://ortussolutions.atlassian.net/browse/BL-910) Passing query column to listToArray\(\) BIF fails

[BL-911](https://ortussolutions.atlassian.net/browse/BL-911) IsNumeric BIF returns true on booleans in compat mode

[BL-912](https://ortussolutions.atlassian.net/browse/BL-912) getBaseTemplatePath returns \`Application.cfc\` in onRequestStart

[BL-913](https://ortussolutions.atlassian.net/browse/BL-913) Throw with exception object as unnamed argument fails

[BL-914](https://ortussolutions.atlassian.net/browse/BL-914) Null session scope when attempting to update the last visit

[BL-917](https://ortussolutions.atlassian.net/browse/BL-917) Compat GetComponentMetadata Failures with "Can't cast null to a Key".

[BL-918](https://ortussolutions.atlassian.net/browse/BL-918) String \[1 LTE 5\] cannot be cast to a boolean

[BL-923](https://ortussolutions.atlassian.net/browse/BL-923) Compat: Attributes to Functions Are Scoped in to nested Parameters Struct

[BL-925](https://ortussolutions.atlassian.net/browse/BL-925) Cannot invoke method \[clearbuffer\(\)\] on a null object

[BL-927](https://ortussolutions.atlassian.net/browse/BL-927) Double variable assignment failing in ASM

[BL-928](https://ortussolutions.atlassian.net/browse/BL-928) Compat: Invoke method has different required object method

[BL-930](https://ortussolutions.atlassian.net/browse/BL-930) StructFindKey Returns a Null Value when Struct being searched contains nulls

[BL-932](https://ortussolutions.atlassian.net/browse/BL-932) toBinary\(\) not lenient enough for decoding with line paddings

[BL-936](https://ortussolutions.atlassian.net/browse/BL-936) When doing named parameter queries and you send more parameters than required, it should ignore them, not throw an exception that you sent more

[BL-937](https://ortussolutions.atlassian.net/browse/BL-937) getOrCreateSession\(\) relying on the starting listener for settings, when it should look at the context to reflect changes if any

[BL-941](https://ortussolutions.atlassian.net/browse/BL-941) WebRequest interceptor in web support is not auto-loading, also will affect any other composable runtimes

[BL-944](https://ortussolutions.atlassian.net/browse/BL-944) node.xmlText explicit assignment throws error that value is not node or XML instance

[BL-945](https://ortussolutions.atlassian.net/browse/BL-945) xmlAttributes assignment error - key not found

### New Feature

[BL-94](https://ortussolutions.atlassian.net/browse/BL-94) Create query of queries support

[BL-310](https://ortussolutions.atlassian.net/browse/BL-310) Spread operator

[BL-311](https://ortussolutions.atlassian.net/browse/BL-311) Implement Array Destructuring assignment

[BL-749](https://ortussolutions.atlassian.net/browse/BL-749) Modularize the JavaBoxPiler so we can have ASM as core

[BL-789](https://ortussolutions.atlassian.net/browse/BL-789) Allow CGI scope to be writable

[BL-843](https://ortussolutions.atlassian.net/browse/BL-843) Move defaultCache to the caches section as default,  verify it exists, else create it anyways

[BL-883](https://ortussolutions.atlassian.net/browse/BL-883) Implement list parameters in JDBC queries

[BL-933](https://ortussolutions.atlassian.net/browse/BL-933) Ability to register custom functions for QoQ

[BL-942](https://ortussolutions.atlassian.net/browse/BL-942) Interceptor Service now does a service loader load of all interceptors found in the runtime to auto load them

### Task

[BL-217](https://ortussolutions.atlassian.net/browse/BL-217) ColdBox Test Suite

[BL-220](https://ortussolutions.atlassian.net/browse/BL-220) Quick Test Suite

[BL-548](https://ortussolutions.atlassian.net/browse/BL-548) Parser performance and removing ambiguity 

[BL-767](https://ortussolutions.atlassian.net/browse/BL-767) CFcasts Suite

[BL-837](https://ortussolutions.atlassian.net/browse/BL-837) UnleashSDK Certification

[BL-908](https://ortussolutions.atlassian.net/browse/BL-908) Incorporate TestBox test suite

### Story

[BL-237](https://ortussolutions.atlassian.net/browse/BL-237) Phase II : Update all the toAST\(\) methods to the new and consolidated approach

[BL-238](https://ortussolutions.atlassian.net/browse/BL-238) Phase III : Performance tests for phase I \+ II toolchains

[BL-239](https://ortussolutions.atlassian.net/browse/BL-239) Phase V : Create the QoQ SQL grammar, parser, and ast

[BL-838]: https://ortussolutions.atlassian.net/browse/BL-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-852]: https://ortussolutions.atlassian.net/browse/BL-852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-860]: https://ortussolutions.atlassian.net/browse/BL-860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-865]: https://ortussolutions.atlassian.net/browse/BL-865?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-866]: https://ortussolutions.atlassian.net/browse/BL-866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-919]: https://ortussolutions.atlassian.net/browse/BL-919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-920]: https://ortussolutions.atlassian.net/browse/BL-920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-926]: https://ortussolutions.atlassian.net/browse/BL-926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ