### PR TITLE
version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -418,7 +418,8 @@ project.ext.bumpVersion = {
 	boolean minor = false,
 	boolean patch = false,
 	boolean beta = false,
-	boolean rc = false ->
+	boolean rc = false,
+	property = "version" ->
 
 	def propertiesFile = file( './gradle.properties' );
 	def properties = new Properties();
@@ -426,22 +427,17 @@ project.ext.bumpVersion = {
 	properties.load( propertiesFile.newDataInputStream() )
 	def versionTarget = major ? 0 : minor ? 1 : beta ? 2 : 3
 
-	def currentVersion = properties.getProperty( 'version' )
-	// 1.1.0 -> -> [ 1, 1, 0 ]
-	// 1.0.0-beta1 -> [ 1, 0, 0-beta1 ]
-	// 1.0.0-rc.1 -> [ 1, 0, 0-rc, 1 ]
+	def currentVersion = properties.getProperty( property )
 	def versionParts = currentVersion.split( '\\.' )
-	if( !beta ){
-		def newPathVersion = versionParts[ versionTarget ].toInteger() + 1
-	}
+	def newPathVersion = versionParts[ versionTarget ].toInteger() + 1
 	def newVersion = '';
 
 	if( patch ){
 		newVersion = "${versionParts[ 0 ]}.${versionParts[ 1 ]}.${newPathVersion}"
 	} else if( minor ){
-		newVersion = "${versionParts[ 0 ]}.${newPathVersion}.${versionParts[ 2 ]}"
+		newVersion = "${versionParts[ 0 ]}.${newPathVersion}.0"
 	} else if( major ){
-		newVersion = "${newPathVersion}.${versionParts[ 1 ]}.${versionParts[ 2 ]}"
+		newVersion = "${newPathVersion}.0.0"
 	} else if( beta ){
 		// Get's the -betaX version.
 		def betaString = currentVersion.split( '-' )[ 1 ]
@@ -449,10 +445,10 @@ project.ext.bumpVersion = {
 		def betaNumber = betaString.split( 'beta' )[ 1 ].toInteger() + 1
 		newVersion = currentVersion.split( '-' )[ 0 ] + "-beta${betaNumber}"
 	} else if( rc ){
-		newVersion = "${versionParts[ 0 ]}.${versionParts[ 1 ]}.${versionParts[ 2 ]}.${versionParts[ 3 ]}"
+		newVersion = "${versionParts[ 0 ]}.${versionParts[ 1 ]}.${versionParts[ 2 ]}.${newPathVersion}"
 	}
 
-	properties.setProperty( 'version', newVersion )
+	properties.setProperty( property, newVersion )
 	properties.store( propertiesFile.newWriter(), null )
 
 	println "Bumped version from ${currentVersion} to ${newVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ if (branch == 'development') {
     // If the branch is 'development', ensure the version ends with '-snapshot'
     // This replaces any existing prerelease identifier with '-snapshot'
     version = version.contains('-') ? version.replaceAll(/-.*/, '-snapshot') : "${version}-snapshot"
-	boxlangVersion = boxlangVersion.contains('-') ? boxlangVersion.replaceAll(/-.*/, '-snapshot') : "${boxlangVersion}-snapshot"
+	boxlangVersion = boxlangVersion.contains('-') ? boxlangVersion.replaceAll(/-.*/, '-snapshot') : "${boxlangVersion}-snapshot".toString()
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ ext {
 if (branch == 'development') {
     // If the branch is 'development', ensure the version ends with '-snapshot'
     // This replaces any existing prerelease identifier with '-snapshot'
-    version = version.contains('-') ? version.replaceAll(/-.*/, '-snapshot') : "${version}-snapshot"
+    version = version.contains('-') ? version.replaceAll(/-.*/, '-snapshot') : "${version}-snapshot".toString()
 	boxlangVersion = boxlangVersion.contains('-') ? boxlangVersion.replaceAll(/-.*/, '-snapshot') : "${boxlangVersion}-snapshot".toString()
 }
 
@@ -47,14 +47,14 @@ repositories {
 dependencies {
 	// LOCAL DEVELOPMENT ONLY
 	// CHOOSE THE RIGHT LOCATION FOR YOUR LOCAL DEPENDENCIES
-	// if ( file( '../boxlang/build/libs/boxlang-' + boxlangVersion + '.jar' ).exists() ) {
-    // 	compileOnly files( '../boxlang/build/libs/boxlang-' + boxlangVersion + '.jar' )
-	// 	testImplementation files( '../boxlang/build/libs/boxlang-' + boxlangVersion + '.jar' )
-	// } else {
+	 if ( file( '../boxlang/build/libs/boxlang-' + boxlangVersion + '.jar' ).exists() ) {
+    	compileOnly files( '../boxlang/build/libs/boxlang-' + boxlangVersion + '.jar' )
+		testImplementation files( '../boxlang/build/libs/boxlang-' + boxlangVersion + '.jar' )
+	} else {
 		// Production Dependency
    		compileOnly files( 'src/test/resources/libs/boxlang-' + boxlangVersion + '.jar' )
 		testImplementation files( 'src/test/resources/libs/boxlang-' + boxlangVersion + '.jar' )
-	// }
+	}
 
 	// For HTML Parsing
 	implementation 'org.jsoup:jsoup:1.19.1'

--- a/changelog.md
+++ b/changelog.md
@@ -9,3 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2025-04-30
+
+[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0...HEAD
+
+[1.0.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/f74945aeba03311b7fdb25519947c334110b1b63...v1.0.0

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### New Features
+
+- [BL-1365](https://ortussolutions.atlassian.net/browse/BL-1365) Add parse\(\) helper methods directly to runtime which returns parse result
+- [BL-1388](https://ortussolutions.atlassian.net/browse/BL-1388) new security configuration item: populateServerSystemScope that can allow or not the population of the server.system scope or not
+
+### Improvements
+
+- [BL-1333](https://ortussolutions.atlassian.net/browse/BL-1333) Create links to BoxLang modules
+- [BL-1351](https://ortussolutions.atlassian.net/browse/BL-1351) match getHTTPTimeString\(\) and default time to now
+- [BL-1358](https://ortussolutions.atlassian.net/browse/BL-1358) Work harder to return partial AST on invalid parse
+- [BL-1363](https://ortussolutions.atlassian.net/browse/BL-1363) Error executing dump template \[/dump/html/BoxClass.bxm\]
+- [BL-1375](https://ortussolutions.atlassian.net/browse/BL-1375) Compat - Move Legacy Date Format Interception to Module-Specific Interception Point
+- [BL-1381](https://ortussolutions.atlassian.net/browse/BL-1381) allow box class to be looped over as collection
+- [BL-1382](https://ortussolutions.atlassian.net/browse/BL-1382) Rework event bus interceptors to accelerate during executions
+- [BL-1383](https://ortussolutions.atlassian.net/browse/BL-1383) Compat - Allow handling of decimals where timespan is used
+- [BL-1387](https://ortussolutions.atlassian.net/browse/BL-1387) Allow Numeric ApplicationTimeout assignment to to be decimal
+
+### Bugs
+
+- [BL-1354](https://ortussolutions.atlassian.net/browse/BL-1354) BoxLang date time not accepted by JDBC as a date object
+- [BL-1359](https://ortussolutions.atlassian.net/browse/BL-1359) contracting path doesn't work if casing of mapping doesn't match casing of abs path
+- [BL-1366](https://ortussolutions.atlassian.net/browse/BL-1366) sessionInvalidate\(\) "Cannot invoke String.length\(\) because "s" is null"
+- [BL-1370](https://ortussolutions.atlassian.net/browse/BL-1370) Some methods not found in java interop
+- [BL-1372](https://ortussolutions.atlassian.net/browse/BL-1372) string functions accepting null
+- [BL-1374](https://ortussolutions.atlassian.net/browse/BL-1374) onMissingTemplate event mystyped as missingtemplate
+- [BL-1377](https://ortussolutions.atlassian.net/browse/BL-1377) fileExists\(\) not working with relative paths
+- [BL-1378](https://ortussolutions.atlassian.net/browse/BL-1378) optional capture groups throw NPE in reReplace\(\)
+- [BL-1379](https://ortussolutions.atlassian.net/browse/BL-1379) array length incorrect for xml nodes
+- [BL-1384](https://ortussolutions.atlassian.net/browse/BL-1384) Numeric Session Timeout Values Should Be Duration of Days  not Seconds
+
 ## [1.0.0] - 2025-04-30
 
 [Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0...HEAD

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #Thu Apr 03 10:01:03 UTC 2025
-boxlangVersion=1.0.0
+boxlangVersion=1.1.0
 jdkVersion=21
-version=1.0.0
+version=1.1.0
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/bifs/GetHTTPTimeString.java
+++ b/src/main/java/ortus/boxlang/web/bifs/GetHTTPTimeString.java
@@ -19,18 +19,16 @@
 package ortus.boxlang.web.bifs;
 
 import java.time.ZoneId;
-import java.util.Set;
 
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
 import ortus.boxlang.runtime.context.IBoxContext;
-import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.dynamic.casters.DateTimeCaster;
 import ortus.boxlang.runtime.scopes.ArgumentsScope;
 import ortus.boxlang.runtime.scopes.Key;
 import ortus.boxlang.runtime.types.Argument;
 import ortus.boxlang.runtime.types.DateTime;
-import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
-import ortus.boxlang.runtime.validation.Validator;
+import ortus.boxlang.runtime.util.LocalizationUtil;
 
 @BoxBIF
 
@@ -42,7 +40,7 @@ public class GetHTTPTimeString extends BIF {
 	public GetHTTPTimeString() {
 		super();
 		declaredArguments = new Argument[] {
-		    new Argument( true, "any", Key.date, Set.of( Validator.typeOneOf( "datetime", "string" ) ) )
+		    new Argument( false, "any", Key.date )
 		};
 	}
 
@@ -55,14 +53,12 @@ public class GetHTTPTimeString extends BIF {
 	 * @argument.foo Describe any expected arguments
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
-		DateTime dateRef = null;
-		try {
-			dateRef = arguments.getAsDateTime( Key.date );
-		} catch ( java.lang.ClassCastException e ) {
-			throw new BoxRuntimeException(
-			    String.format( "The provided date value [%s] could not be cast to a DateTime value", StringCaster.cast( arguments.get( Key.date ) ) ) );
+		Object dateArg = arguments.get( Key.date );
+		if ( dateArg == null ) {
+			dateArg = new DateTime( LocalizationUtil.parseZoneId( null, context ) );
 		}
-		DateTime converted = dateRef.convertToZone( ZoneId.of( "UTC" ) );
+		DateTime	dateRef		= DateTimeCaster.cast( dateArg );
+		DateTime	converted	= dateRef.convertToZone( ZoneId.of( "UTC" ) );
 		converted.setFormat( "EEE, dd MMM yyyy HH:mm:ss z" );
 
 		return converted.toString();

--- a/src/main/java/ortus/boxlang/web/exchange/BoxCookie.java
+++ b/src/main/java/ortus/boxlang/web/exchange/BoxCookie.java
@@ -70,7 +70,7 @@ public class BoxCookie {
 	 * @return The cookie value, encoded if necessary
 	 */
 	public String getEncodedValue() {
-		if ( encodeValue ) {
+		if ( encodeValue && value != null ) {
 			return URLEncoder.encode( value, java.nio.charset.StandardCharsets.UTF_8 );
 		}
 		return value;
@@ -255,7 +255,9 @@ public class BoxCookie {
 	 */
 	public static BoxCookie fromEncoded( String name, String value ) {
 		try {
-			value = URLDecoder.decode( value, java.nio.charset.StandardCharsets.UTF_8 );
+			if ( value != null ) {
+				value = URLDecoder.decode( value, java.nio.charset.StandardCharsets.UTF_8 );
+			}
 		} catch ( IllegalArgumentException e ) {
 			// TODO: remove this later. Just want to see if it happens in the wild.
 			System.out.println( "IllegalArgumentException decoding cookie name: [" + name + "] value: [" + value + "] error: " + e.getMessage() );

--- a/src/test/java/ortus/boxlang/web/bifs/GetHTTPTimeStringTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/GetHTTPTimeStringTest.java
@@ -72,6 +72,9 @@ public class GetHTTPTimeStringTest {
 		assertThat( variables.getAsString( result ) ).isEqualTo( resultRef );
 
 		assertThrows( BoxRuntimeException.class, () -> instance.executeSource( "result = getHttpTimeString( 'foo' );", context ) );
+
+		instance.executeSource( "result = getHttpTimeString();", context );
+		assertThat( variables.getAsString( result ) ).isInstanceOf( String.class );
 	}
 
 }


### PR DESCRIPTION
### New Features

- [BL-1365](https://ortussolutions.atlassian.net/browse/BL-1365) Add parse\(\) helper methods directly to runtime which returns parse result
- [BL-1388](https://ortussolutions.atlassian.net/browse/BL-1388) new security configuration item: populateServerSystemScope that can allow or not the population of the server.system scope or not

### Improvements

- [BL-1333](https://ortussolutions.atlassian.net/browse/BL-1333) Create links to BoxLang modules
- [BL-1351](https://ortussolutions.atlassian.net/browse/BL-1351) match getHTTPTimeString\(\) and default time to now
- [BL-1358](https://ortussolutions.atlassian.net/browse/BL-1358) Work harder to return partial AST on invalid parse
- [BL-1363](https://ortussolutions.atlassian.net/browse/BL-1363) Error executing dump template \[/dump/html/BoxClass.bxm\]
- [BL-1375](https://ortussolutions.atlassian.net/browse/BL-1375) Compat - Move Legacy Date Format Interception to Module-Specific Interception Point
- [BL-1381](https://ortussolutions.atlassian.net/browse/BL-1381) allow box class to be looped over as collection
- [BL-1382](https://ortussolutions.atlassian.net/browse/BL-1382) Rework event bus interceptors to accelerate during executions
- [BL-1383](https://ortussolutions.atlassian.net/browse/BL-1383) Compat - Allow handling of decimals where timespan is used
- [BL-1387](https://ortussolutions.atlassian.net/browse/BL-1387) Allow Numeric ApplicationTimeout assignment to to be decimal

### Bugs

- [BL-1354](https://ortussolutions.atlassian.net/browse/BL-1354) BoxLang date time not accepted by JDBC as a date object
- [BL-1359](https://ortussolutions.atlassian.net/browse/BL-1359) contracting path doesn't work if casing of mapping doesn't match casing of abs path
- [BL-1366](https://ortussolutions.atlassian.net/browse/BL-1366) sessionInvalidate\(\) "Cannot invoke String.length\(\) because "s" is null"
- [BL-1370](https://ortussolutions.atlassian.net/browse/BL-1370) Some methods not found in java interop
- [BL-1372](https://ortussolutions.atlassian.net/browse/BL-1372) string functions accepting null
- [BL-1374](https://ortussolutions.atlassian.net/browse/BL-1374) onMissingTemplate event mystyped as missingtemplate
- [BL-1377](https://ortussolutions.atlassian.net/browse/BL-1377) fileExists\(\) not working with relative paths
- [BL-1378](https://ortussolutions.atlassian.net/browse/BL-1378) optional capture groups throw NPE in reReplace\(\)
- [BL-1379](https://ortussolutions.atlassian.net/browse/BL-1379) array length incorrect for xml nodes
- [BL-1384](https://ortussolutions.atlassian.net/browse/BL-1384) Numeric Session Timeout Values Should Be Duration of Days  not Seconds

[BL-1365]: https://ortussolutions.atlassian.net/browse/BL-1365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1388]: https://ortussolutions.atlassian.net/browse/BL-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1333]: https://ortussolutions.atlassian.net/browse/BL-1333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1351]: https://ortussolutions.atlassian.net/browse/BL-1351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1358]: https://ortussolutions.atlassian.net/browse/BL-1358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1363]: https://ortussolutions.atlassian.net/browse/BL-1363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1375]: https://ortussolutions.atlassian.net/browse/BL-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1381]: https://ortussolutions.atlassian.net/browse/BL-1381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1382]: https://ortussolutions.atlassian.net/browse/BL-1382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ