### PR TITLE
BL-1607

### DIFF
--- a/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
+++ b/src/main/java/ortus/boxlang/web/context/WebRequestBoxContext.java
@@ -181,7 +181,13 @@ public class WebRequestBoxContext extends RequestBoxContext {
 					BoxCookie sessionCookie = httpExchange
 					    .getRequestCookie( sessionCookieDefaults.getAsString( Key._NAME ) );
 					if ( sessionCookie != null ) {
-						this.sessionID = Key.of( sessionCookie.getValue() );
+						String idValue = sessionCookie.getValue();
+						// We need to ensure that we are not dealing with the null value set by `resetSession()`
+						if ( idValue != null ) {
+							this.sessionID = Key.of( sessionCookie.getValue() );
+						} else {
+							this.sessionID = Key.of( UUID.randomUUID().toString() );
+						}
 					} else {
 						// Otherwise generate a new one
 						this.sessionID	= Key.of( UUID.randomUUID().toString() );

--- a/src/test/java/ortus/boxlang/web/bifs/SessionInvalidateTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/SessionInvalidateTest.java
@@ -1,0 +1,88 @@
+
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.web.bifs;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.IStruct;
+
+public class SessionInvalidateTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It tests the BIF SessionInvalidate" )
+	@Test
+	public void testBif() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+				bx:application name="unit-test-sm" sessionmanagement="true";
+				session.foo = "bar";
+				initialSession = duplicate( session );
+		    	sleep( 1000 );
+				SessionInvalidate();
+				result = session;
+
+				println( result.asString() )
+			""",
+		    context );
+		// @formatter:on
+
+		IStruct initialSession = variables.getAsStruct( Key.of( "initialSession" ) );
+		assertFalse( variables.getAsStruct( result ).containsKey( Key.of( "foo" ) ) );
+		assertNotEquals( initialSession.getAsString( Key.of( "jsessionID" ) ), variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) );
+		assertFalse(
+		    initialSession.getAsDateTime( Key.of( "timeCreated" ) ).equals( variables.getAsStruct( result ).getAsDateTime( Key.of( "timeCreated" ) ) ) );
+		assertFalse( variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) == null );
+		assertNotEquals( initialSession.getAsString( Key.of( "sessionid" ) ), variables.getAsStruct( result ).getAsString( Key.of( "sessionid" ) ) );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/web/bifs/SessionInvalidateTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/SessionInvalidateTest.java
@@ -21,6 +21,7 @@ package ortus.boxlang.web.bifs;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -81,7 +82,7 @@ public class SessionInvalidateTest {
 		assertNotEquals( initialSession.getAsString( Key.of( "jsessionID" ) ), variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) );
 		assertFalse(
 		    initialSession.getAsDateTime( Key.of( "timeCreated" ) ).equals( variables.getAsStruct( result ).getAsDateTime( Key.of( "timeCreated" ) ) ) );
-		assertFalse( variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) == null );
+		assertNotNull( variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) );
 		assertNotEquals( initialSession.getAsString( Key.of( "sessionid" ) ), variables.getAsStruct( result ).getAsString( Key.of( "sessionid" ) ) );
 	}
 

--- a/src/test/java/ortus/boxlang/web/bifs/SessionRotateTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/SessionRotateTest.java
@@ -1,0 +1,90 @@
+
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ortus.boxlang.web.bifs;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.BoxRuntime;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.context.ScriptingRequestBoxContext;
+import ortus.boxlang.runtime.scopes.IScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.scopes.VariablesScope;
+import ortus.boxlang.runtime.types.IStruct;
+
+public class SessionRotateTest {
+
+	static BoxRuntime	instance;
+	IBoxContext			context;
+	IScope				variables;
+	static Key			result	= new Key( "result" );
+
+	@BeforeAll
+	public static void setUp() {
+		instance = BoxRuntime.getInstance( true );
+	}
+
+	@AfterAll
+	public static void teardown() {
+	}
+
+	@BeforeEach
+	public void setupEach() {
+		context		= new ScriptingRequestBoxContext( instance.getRuntimeContext() );
+		variables	= context.getScopeNearby( VariablesScope.name );
+	}
+
+	@DisplayName( "It tests the BIF SessionRotate" )
+	@Test
+	public void testBif() {
+		// @formatter:off
+		instance.executeSource(
+		    """
+				bx:application name="unit-test-sm" sessionmanagement="true";
+				session.foo = "bar";
+				initialSession = duplicate( session );
+		    	println( initialSession.asString() )
+				sleep( 1000 );
+				SessionRotate();
+				result = session;
+
+				println( result.asString() )
+			""",
+		    context );
+		// @formatter:on
+
+		IStruct initialSession = variables.getAsStruct( Key.of( "initialSession" ) );
+		assertTrue( variables.getAsStruct( result ).containsKey( Key.of( "foo" ) ) );
+		assertNotEquals( initialSession.getAsString( Key.of( "jsessionID" ) ), variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) );
+		assertFalse(
+		    initialSession.getAsDateTime( Key.of( "timeCreated" ) ).equals( variables.getAsStruct( result ).getAsDateTime( Key.of( "timeCreated" ) ) ) );
+		assertFalse( variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) == null );
+		assertNotEquals( initialSession.getAsString( Key.of( "sessionid" ) ), variables.getAsStruct( result ).getAsString( Key.of( "sessionid" ) ) );
+	}
+
+}

--- a/src/test/java/ortus/boxlang/web/bifs/SessionRotateTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/SessionRotateTest.java
@@ -21,6 +21,7 @@ package ortus.boxlang.web.bifs;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.AfterAll;
@@ -83,7 +84,7 @@ public class SessionRotateTest {
 		assertNotEquals( initialSession.getAsString( Key.of( "jsessionID" ) ), variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) );
 		assertFalse(
 		    initialSession.getAsDateTime( Key.of( "timeCreated" ) ).equals( variables.getAsStruct( result ).getAsDateTime( Key.of( "timeCreated" ) ) ) );
-		assertFalse( variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) == null );
+		assertNotNull( variables.getAsStruct( result ).getAsString( Key.of( "jsessionID" ) ) );
 		assertNotEquals( initialSession.getAsString( Key.of( "sessionid" ) ), variables.getAsStruct( result ).getAsString( Key.of( "sessionid" ) ) );
 	}
 


### PR DESCRIPTION
Ensure null session ID is not propagated from resetSession cookie

## Jira/Github Issues

https://ortussolutions.atlassian.net/browse/BL-1607

## Type of change

- [X] Bug Fix

## Checklist

- [X] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
