### PR TITLE
v1.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
         if: env.SNAPSHOT == 'false'
         run: |
           ./gradlew publish --no-daemon --no-parallel
-          ./gradlew publishAllPublicationsToCentralPortal
+          ./gradlew publishAggregationToCentralPortal --stacktrace --info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_KEY: ${{ secrets.GPG_KEY }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "windows-latest"]
-        jdkVersion: ["21"]
-        experimental: [false]
+        os: [ "ubuntu-latest", "windows-latest" ]
+        jdkVersion: [ "21" ]
+        experimental: [ false ]
         #include:
         #- jdkVersion: "21"
         #  os: "windows-latest"
@@ -34,10 +34,10 @@ jobs:
         #  experimental: true
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: ${{ matrix.jdkVersion }}
@@ -71,6 +71,20 @@ jobs:
           ./gradlew downloadBoxLang
           ./gradlew test --stacktrace --console=plain
 
+      - name: Publish Test Reports
+        uses: mikepenz/action-junit-report@v5.6.2
+        if: always()
+        with:
+          report_paths: |
+            **/build/test-results/test/*.xml
+            **/surefire-reports/*.xml
+            **/failsafe-reports/*.xml
+          check_name: "JUnit Report ${{ matrix.os }}-${{ matrix.jdkVersion }}"
+          include_passed: false
+          fail_on_failure: true
+          summary: "Test Results for ${{ matrix.os }} with compiler on JDK ${{ matrix.jdkVersion }}"
+          detailed_summary: true
+
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v4
@@ -92,25 +106,3 @@ jobs:
           SLACK_USERNAME: CI
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_URL }}
           MSG_MINIMAL: true
-
-  publish-test-results:
-    name: Publish Test Results
-    runs-on: ubuntu-latest
-    needs: tests
-    if: always()
-    permissions:
-      checks: write
-      pull-requests: write
-      contents: read
-      issues: read
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: artifacts
-
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        with:
-          files: |
-            artifacts/**/*.xml

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 	// https://github.com/harbby/gradle-serviceloader
     id "com.github.harbby.gradle.serviceloader" version "1.1.9"
 	// Shadow
-	id "com.gradleup.shadow" version "9.0.0-rc2"
+	id "com.gradleup.shadow" version "9.0.2"
     // Download task
     id "de.undercouch.download" version "5.6.0"
 	// Task visualizer
@@ -19,7 +19,7 @@ plugins {
 	// Maven Publisher
 	id 'maven-publish'
 	id 'signing'
-	id 'com.gradleup.nmcp' version "0.0.9"
+	id 'com.gradleup.nmcp.aggregation' version "1.1.0"
 }
 
 /**
@@ -275,24 +275,38 @@ publishing {
     }
 }
 
-nmcp {
-  publishAllProjectsProbablyBreakingProjectIsolation {
-    username = System.getenv( "MAVEN_USERNAME" ) ?: project.findProperty( "maven_username" )
-    password = System.getenv( "MAVEN_PASSWORD" ) ?: project.findProperty( "maven_password" )
-    // publish manually from the portal
-    //publicationType = "USER_MANAGED"
-    // or if you want to publish automatically
-    publicationType = "AUTOMATIC"
-  }
+/**
+ * Maven Central Publishing
+ * Plugin Information here: https://github.com/gradleup/nmcp
+ */
+nmcpAggregation {
+	centralPortal {
+		username = System.getenv( "MAVEN_USERNAME" ) ?: findProperty( "maven_username" )
+		password = System.getenv( "MAVEN_PASSWORD" ) ?: findProperty( "maven_password" )
+		// Manual release from the Portal UI:
+		// publishingType = "USER_MANAGED"
+		// Or auto-release:
+		publishingType = "AUTOMATIC"
+	}
+
+	// Publishes all subprojects that apply 'maven-publish'
+  	publishAllProjectsProbablyBreakingProjectIsolation()
 }
 
 /**
  * Digital Signing of assets
  */
 signing {
-	def signingKey = System.getenv("GPG_KEY") ?: project.findProperty("signing.keyId")
-	def signingPassword = System.getenv("GPG_PASSWORD") ?: project.findProperty("signing.password")
-    useInMemoryPgpKeys(signingKey, signingPassword)
+	// Check if we have environment variables for in-memory PGP keys (CI/CD)
+	def gpgKey = System.getenv( "GPG_KEY" )
+	def gpgPassword = System.getenv( "GPG_PASSWORD" )
+
+	if ( gpgKey && gpgPassword ) {
+		// Use in-memory PGP keys for CI/CD
+		useInMemoryPgpKeys( gpgKey, gpgPassword )
+	}
+	// Otherwise use traditional gradle.properties approach for local development
+
     sign publishing.publications.shadow
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2025-08-02
+
 ## [1.3.0] - 2025-06-23
 
 ## [1.2.0] - 2025-05-29
@@ -47,12 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.0] - 2025-04-30
 
-[Unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.3.0...HEAD
-
+[unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.2.0...v1.3.0
-
 [1.2.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.1.0...v1.2.0
-
 [1.1.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0...v1.1.0
-
 [1.0.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/f74945aeba03311b7fdb25519947c334110b1b63...v1.0.0

--- a/changelog.md
+++ b/changelog.md
@@ -9,49 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- https://boxlang.ortusbooks.com/readme/release-history/1.5.0
+
 ## [1.4.0] - 2025-08-02
+
+- https://boxlang.ortusbooks.com/readme/release-history/1.4.0
 
 ## [1.3.0] - 2025-06-23
 
+- https://boxlang.ortusbooks.com/readme/release-history/1.3.0
+
 ## [1.2.0] - 2025-05-29
+
+- https://boxlang.ortusbooks.com/readme/release-history/1.2.0
 
 ## [1.1.0] - 2025-05-12
 
-### New Features
+- https://boxlang.ortusbooks.com/readme/release-history/1.1.0
 
-- [BL-1365](https://ortussolutions.atlassian.net/browse/BL-1365) Add parse() helper methods directly to runtime which returns parse result
-- [BL-1388](https://ortussolutions.atlassian.net/browse/BL-1388) new security configuration item: populateServerSystemScope that can allow or not the population of the server.system scope or not
+## [1.0.1] - 2025-05-01
 
-### Improvements
-
-- [BL-1333](https://ortussolutions.atlassian.net/browse/BL-1333) Create links to BoxLang modules
-- [BL-1351](https://ortussolutions.atlassian.net/browse/BL-1351) match getHTTPTimeString() and default time to now
-- [BL-1358](https://ortussolutions.atlassian.net/browse/BL-1358) Work harder to return partial AST on invalid parse
-- [BL-1363](https://ortussolutions.atlassian.net/browse/BL-1363) Error executing dump template \[/dump/html/BoxClass.bxm]
-- [BL-1375](https://ortussolutions.atlassian.net/browse/BL-1375) Compat - Move Legacy Date Format Interception to Module-Specific Interception Point
-- [BL-1381](https://ortussolutions.atlassian.net/browse/BL-1381) allow box class to be looped over as collection
-- [BL-1382](https://ortussolutions.atlassian.net/browse/BL-1382) Rework event bus interceptors to accelerate during executions
-- [BL-1383](https://ortussolutions.atlassian.net/browse/BL-1383) Compat - Allow handling of decimals where timespan is used
-- [BL-1387](https://ortussolutions.atlassian.net/browse/BL-1387) Allow Numeric ApplicationTimeout assignment to to be decimal
-
-### Bugs
-
-- [BL-1354](https://ortussolutions.atlassian.net/browse/BL-1354) BoxLang date time not accepted by JDBC as a date object
-- [BL-1359](https://ortussolutions.atlassian.net/browse/BL-1359) contracting path doesn't work if casing of mapping doesn't match casing of abs path
-- [BL-1366](https://ortussolutions.atlassian.net/browse/BL-1366) sessionInvalidate() "Cannot invoke String.length() because "s" is null"
-- [BL-1370](https://ortussolutions.atlassian.net/browse/BL-1370) Some methods not found in java interop
-- [BL-1372](https://ortussolutions.atlassian.net/browse/BL-1372) string functions accepting null
-- [BL-1374](https://ortussolutions.atlassian.net/browse/BL-1374) onMissingTemplate event mystyped as missingtemplate
-- [BL-1377](https://ortussolutions.atlassian.net/browse/BL-1377) fileExists() not working with relative paths
-- [BL-1378](https://ortussolutions.atlassian.net/browse/BL-1378) optional capture groups throw NPE in reReplace()
-- [BL-1379](https://ortussolutions.atlassian.net/browse/BL-1379) array length incorrect for xml nodes
-- [BL-1384](https://ortussolutions.atlassian.net/browse/BL-1384) Numeric Session Timeout Values Should Be Duration of Days  not Seconds
+- https://boxlang.ortusbooks.com/readme/release-history/1.0.1
 
 ## [1.0.0] - 2025-04-30
 
-[unreleased]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.4.0...HEAD
-[1.4.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.3.0...v1.4.0
-[1.3.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.2.0...v1.3.0
-[1.2.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.1.0...v1.2.0
-[1.1.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/v1.0.0...v1.1.0
-[1.0.0]: https://github.com/ortus-boxlang/boxlang-web-support/compare/f74945aeba03311b7fdb25519947c334110b1b63...v1.0.0
+- https://boxlang.ortusbooks.com/readme/release-history/1.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-#Mon Jun 23 16:07:23 UTC 2025
-boxlangVersion=1.4.0
+#Sat Aug 02 12:14:05 UTC 2025
+boxlangVersion=1.5.0
 jdkVersion=21
-version=1.4.0
+version=1.5.0
 group=ortus.boxlang

--- a/src/main/java/ortus/boxlang/web/bifs/FileUpload.java
+++ b/src/main/java/ortus/boxlang/web/bifs/FileUpload.java
@@ -74,6 +74,47 @@ public class FileUpload extends BIF {
 	/**
 	 * Processes file uploads from the request into the specified destination directory.
 	 *
+	 * <ul>
+	 * <li>If the destination is not an absolute path, it will be resolved relative to the system's temporary directory.</li>
+	 * <li>If the file field is not specified, the first file upload in the request will be used.</li>
+	 * <li>If the upload is not permitted by the server, application, or request file security settings, it will be rejected.</li>
+	 * <li>If a file with the same name already exists in the destination directory, the action specified by the `nameconflict` argument will be taken:
+	 * <ul>
+	 * <li>`error`: The upload will be rejected if a file with the same name exists.</li>
+	 * <li>`skip`: The existing file will not be overwritten.</li>
+	 * <li>`overwrite`: The existing file will be replaced with the uploaded file.</li>
+	 * <li>`makeunique`: The uploaded file will be renamed to make it unique (e.g., by appending a timestamp).</li>
+	 * </ul>
+	 * </li>
+	 * <li>If the upload violates any security policies and `strict` is true, an exception will be thrown. If `strict` is false, the upload will be
+	 * skipped
+	 * if it violates security policies.</li>
+	 * <li>The uploaded file's metadata will be returned in an IStruct, which includes:
+	 * <ul>
+	 * <li>`clientDirectory`: The directory location of the file uploaded from the client's system.</li>
+	 * <li>`clientFile`: The name of the file uploaded from the client's system.</li>
+	 * <li>`clientFileExt`: The extension of the uploaded file on the client system (without a period).</li>
+	 * <li>`clientFileName`: The name of the uploaded file on the client system (without an extension).</li>
+	 * <li>`contentType`: The MIME content type of the saved file.</li>
+	 * <li>`contentSubType`: The MIME content subtype of the saved file.</li>
+	 * <li>`dateLastAccessed`: The date and time the uploaded file was last accessed.</li>
+	 * <li>`fileExisted`: Whether the file existed with the same path (yes or no).</li>
+	 * <li>`fileSize`: The size of the uploaded file in bytes.</li>
+	 * <li>`fileWasAppended`: Whether ColdFusion appended the uploaded file to a file (yes or no).</li>
+	 * <li>`fileWasOverwritten`: Whether ColdFusion overwrote a file (yes or no).</li>
+	 * <li>`fileWasRenamed`: Whether the uploaded file was renamed to avoid a name conflict (yes or no).</li>
+	 * <li>`fileWasSaved`: Whether ColdFusion saved a file (yes or no).</li>
+	 * <li>`oldFileSize`: The size of a file that was overwritten in the file upload operation.</li>
+	 * <li>`serverDirectory`: The directory of the file saved on the server.</li>
+	 * <li>`serverFile`: The filename of the file saved on the server.</li>
+	 * <li>`serverFileExt`: The extension of the uploaded file on the server (without a period).</li>
+	 * <li>`serverFileName`: The name of the uploaded file on the server (without an extension).</li>
+	 * <li>`timeCreated`: The time the uploaded file was created.</li>
+	 * <li>`timeLastModified`: The date and time of the last modification to the uploaded file.</li>
+	 * </ul>
+	 * </li>
+	 * </ul>
+	 *
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
@@ -82,15 +123,20 @@ public class FileUpload extends BIF {
 	 *
 	 * @argument.filefield The name of the file field to process. If not specified, the first file upload in the request will be used.
 	 *
-	 * @argument.accept The accepted MIME types for the uploaded files.
+	 * @argument.accept The accepted MIME types for the uploaded files. This can be a comma-separated list of MIME types or a single string or an array.
 	 *
-	 * @argument.nameconflict The action to take when a file with the same name already exists in the destination directory.
+	 * @argument.nameconflict The action to take when a file with the same name already exists in the destination directory. The default is "error", which
+	 *                        means that the upload will be rejected if a file with the same name exists. Other options are "skip" (do not overwrite),
+	 *                        "overwrite" (replace the existing file), and "makeunique" (rename the uploaded file to make it unique).
 	 *
-	 * @argument.strict Whether to strictly enforce the system specified upload security settings.
+	 * @argument.strict Whether to strictly enforce the system specified upload security settings. The default is true, which means that the upload will
+	 *                  be rejected if it violates any security policies.
 	 *
-	 * @argument.allowedExtensions The allowed file extensions for the uploaded files.
+	 * @argument.allowedExtensions The allowed file extensions for the uploaded files. This can be a comma-separated list of extensions or a single string
+	 *                             or an array.
 	 *
-	 *
+	 * @argument.blockedExtensions The blocked file extensions for the uploaded files. This can be a comma-separated list of extensions or a single string
+	 *                             or an array.
 	 *
 	 * @throws BoxRuntimeException if no file uploads are found in the request or if the specified file field is not found.
 	 * @throws BoxIOException      if there is an error creating directories or moving files.

--- a/src/main/java/ortus/boxlang/web/bifs/FileUpload.java
+++ b/src/main/java/ortus/boxlang/web/bifs/FileUpload.java
@@ -1,4 +1,3 @@
-
 /**
  * [BoxLang]
  *
@@ -25,6 +24,8 @@ import java.nio.file.attribute.FileTime;
 import java.util.Set;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.FilenameUtils;
+
 import ortus.boxlang.compiler.parser.Parser;
 import ortus.boxlang.runtime.bifs.BIF;
 import ortus.boxlang.runtime.bifs.BoxBIF;
@@ -49,7 +50,6 @@ import ortus.boxlang.web.util.KeyDictionary;
 
 @BoxBIF
 @BoxBIF( alias = "FileUploadAll" )
-
 public class FileUpload extends BIF {
 
 	/**
@@ -63,40 +63,56 @@ public class FileUpload extends BIF {
 		    new Argument( false, "string", Key.accept ),
 		    new Argument( false, "string", Key.nameconflict, "error", Set.of( Validator.valueOneOf( "error", "skip", "overwrite", "makeunique" ) ) ),
 		    new Argument( false, "boolean", Key.strict, true ),
-		    new Argument( false, "string", KeyDictionary.allowedExtensions )
+		    new Argument( false, "any", KeyDictionary.allowedExtensions ),
+		    new Argument( false, "any", KeyDictionary.blockedExtensions ),
+		    // Still to implement
+		    new Argument( false, "string", Key.attributes ),
+		    new Argument( false, "string", Key.mode )
 		};
 	}
 
 	/**
-	 * Processes file uploads from the request
+	 * Processes file uploads from the request into the specified destination directory.
 	 *
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @argument.destination The destination directory for the uploaded files.
+	 * @argument.destination The destination directory for the uploaded files. If the path is not absolute, it will be resolved relative to the system's
+	 *                       temporary directory.
+	 *
+	 * @argument.filefield The name of the file field to process. If not specified, the first file upload in the request will be used.
 	 *
 	 * @argument.accept The accepted MIME types for the uploaded files.
 	 *
 	 * @argument.nameconflict The action to take when a file with the same name already exists in the destination directory.
 	 *
+	 * @argument.strict Whether to strictly enforce the system specified upload security settings.
+	 *
 	 * @argument.allowedExtensions The allowed file extensions for the uploaded files.
 	 *
-	 * @argument.filefield The name of the file field to process.
 	 *
-	 * @argument.strict Whether to strictly enforce the system specified upload security settings.
+	 *
+	 * @throws BoxRuntimeException if no file uploads are found in the request or if the specified file field is not found.
+	 * @throws BoxIOException      if there is an error creating directories or moving files.
+	 * @throws IOException         if there is an error accessing the file system.
+	 *
+	 * @return An IStruct containing information about the uploaded file(s).
 	 */
 	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		WebRequestBoxContext			requestContext	= context.getParentOfType( WebRequestBoxContext.class );
 		Key								bifMethodKey	= arguments.getAsKey( BIF.__functionName );
-
 		IBoxHTTPExchange				exchange		= requestContext.getHTTPExchange();
-
 		IBoxHTTPExchange.FileUpload[]	uploads			= exchange.getUploadData();
 
+		// Validate the arguments
 		if ( uploads == null ) {
 			throw new BoxRuntimeException( "No file uploads were found in the request" );
-		} else if ( bifMethodKey.equals( KeyDictionary.fileUpload ) ) {
+		}
+
+		// Single File Upload
+		if ( bifMethodKey.equals( KeyDictionary.fileUpload ) ) {
 			String field = arguments.getAsString( Key.filefield );
+			// If no field is specified, use the first upload's form field name
 			if ( field == null ) {
 				field = uploads[ 0 ].formFieldName().getName();
 			}
@@ -112,18 +128,28 @@ public class FileUpload extends BIF {
 			}
 
 			return uploadFile( upload, arguments, context );
-
-		} else {
-			return Stream.of( uploads ).map( upload -> uploadFile( upload, arguments, context ) ).collect( BLCollector.toArray() );
 		}
+
+		// If we reach here then we are processing multiple file uploads
+		return Stream.of( uploads ).map( upload -> uploadFile( upload, arguments, context ) ).collect( BLCollector.toArray() );
 	}
 
+	/**
+	 * Processes a single file upload and saves it to the specified destination directory.
+	 *
+	 * @param upload    The file upload to process.
+	 * @param arguments The arguments for the BIF.
+	 * @param context   The context in which the BIF is being invoked.
+	 *
+	 * @return An IStruct containing information about the uploaded file.
+	 */
 	private IStruct uploadFile( IBoxHTTPExchange.FileUpload upload, IStruct arguments, IBoxContext context ) {
 		String	destination		= arguments.getAsString( Key.destination );
 		Path	destinationPath	= null;
 		Boolean	createPath		= false;
 
 		if ( !Path.of( destination ).isAbsolute() ) {
+			// If the destination is not an absolute path, resolve it relative to the system's temporary directory
 			destinationPath	= Path.of( FileSystemUtil.getTempDirectory(), destination );
 			createPath		= true;
 		} else {
@@ -150,11 +176,12 @@ public class FileUpload extends BIF {
 		Path	filePath		= destinationPath.resolve( fileName );
 		String	nameConflict	= arguments.getAsString( Key.nameconflict ).toLowerCase();
 
+		// Prepare the upload record
 		IStruct	uploadRecord	= newUploadRecord();
 		uploadRecord.put( KeyDictionary.clientDirectory, destinationPath.toString() );
-		uploadRecord.put( KeyDictionary.clientFile, filePath.toString() );
+		uploadRecord.put( KeyDictionary.clientFile, fileName );
 		uploadRecord.put( KeyDictionary.clientFileExt, extension );
-		uploadRecord.put( KeyDictionary.clientFileName, fileName );
+		uploadRecord.put( KeyDictionary.clientFileName, FilenameUtils.getBaseName( fileName ) );
 		uploadRecord.put( KeyDictionary.attemptedServerFile, filePath.toString() );
 
 		try {
@@ -183,7 +210,6 @@ public class FileUpload extends BIF {
 		}
 
 		DateTime operationDate = new DateTime();
-
 		uploadRecord.put( KeyDictionary.timeCreated, operationDate );
 
 		if ( Files.exists( filePath ) ) {
@@ -198,6 +224,8 @@ public class FileUpload extends BIF {
 			} catch ( IOException e ) {
 				throw new BoxIOException( "The size of the original file [" + fileName + "] could not be determined", e );
 			}
+
+			// Handle name conflicts based on the specified action
 			switch ( nameConflict ) {
 				case "error" :
 					throw new BoxRuntimeException( "The file [" + fileName + "] already exists in the destination path [" + destination + "]" );
@@ -230,9 +258,9 @@ public class FileUpload extends BIF {
 			uploadRecord.put( KeyDictionary.contentSubType, ListUtil.asList( mimeType, "/" ).get( 1 ) );
 			uploadRecord.put( KeyDictionary.timeLastModified, operationDate );
 			uploadRecord.put( KeyDictionary.dateLastAccessed, operationDate );
-			uploadRecord.put( KeyDictionary.serverFile, filePath.toString() );
+			uploadRecord.put( KeyDictionary.serverFile, fileName );
 			uploadRecord.put( KeyDictionary.serverFileExt, extension );
-			uploadRecord.put( KeyDictionary.serverFileName, fileName );
+			uploadRecord.put( KeyDictionary.serverFileName, FilenameUtils.getBaseName( fileName ) );
 			uploadRecord.put( KeyDictionary.serverDirectory, filePath.getParent().toString() );
 			uploadRecord.put( KeyDictionary.fileSize, Files.size( filePath ) );
 			uploadRecord.put( KeyDictionary.fileWasSaved, true );
@@ -287,13 +315,12 @@ public class FileUpload extends BIF {
 	public boolean processUploadSecurity( IBoxHTTPExchange.FileUpload upload, IStruct arguments, IBoxContext context ) {
 		// System and request level whitelist and blacklist settings
 		IStruct	requestSettings				= context.getParentOfType( RequestBoxContext.class ).getSettings();
-
 		String	uploadMimeType				= FileSystemUtil.getMimeType( upload.tmpPath().toString() );
 		String	uploadExtension				= Parser.getFileExtension( upload.tmpPath().getFileName().toString() ).get().toLowerCase();
 		String	allowedExtensions			= arguments.getAsString( KeyDictionary.allowedExtensions );
+		String	blockedExtensions			= arguments.getAsString( KeyDictionary.blockedExtensions );
 		String	allowedMimeTypes			= arguments.getAsString( Key.accept );
 		Boolean	strict						= arguments.getAsBoolean( Key.strict );
-
 		Boolean	hasApplicationPermission	= true;
 		Boolean	hasRequestPermission		= true;
 
@@ -301,8 +328,15 @@ public class FileUpload extends BIF {
 			hasRequestPermission = ListUtil.asList( allowedExtensions, ListUtil.DEFAULT_DELIMITER ).stream()
 			    .map( StringCaster::cast )
 			    .anyMatch( ext -> ext.equals( "*" ) || ext.equalsIgnoreCase( uploadExtension ) );
+		}
 
-		} else if ( allowedMimeTypes != null ) {
+		if ( blockedExtensions != null ) {
+			hasRequestPermission = hasRequestPermission && ListUtil.asList( blockedExtensions, ListUtil.DEFAULT_DELIMITER ).stream()
+			    .map( StringCaster::cast )
+			    .noneMatch( ext -> ext.equalsIgnoreCase( uploadExtension ) );
+		}
+
+		if ( allowedMimeTypes != null && allowedExtensions == null && blockedExtensions == null ) {
 			hasRequestPermission = ListUtil.asList( allowedMimeTypes, ListUtil.DEFAULT_DELIMITER ).stream()
 			    .map( StringCaster::cast )
 			    .anyMatch( ext -> ext.equals( "*" ) || ext.equalsIgnoreCase( uploadMimeType ) );
@@ -310,12 +344,18 @@ public class FileUpload extends BIF {
 
 		hasApplicationPermission = FileSystemUtil.isExtensionAllowed( context, uploadExtension );
 
-		return strict
-		    ? hasApplicationPermission && hasRequestPermission
-		    : ( allowedExtensions != null || allowedMimeTypes != null
-		        ? hasRequestPermission
-		        : hasApplicationPermission );
+		// If strict mode, both application and request permissions must be true
+		if ( strict ) {
+			return hasApplicationPermission && hasRequestPermission;
+		}
 
+		// If allowedExtensions, blockedExtensions, or allowedMimeTypes are specified, only check request permission
+		if ( allowedExtensions != null || blockedExtensions != null || allowedMimeTypes != null ) {
+			return hasRequestPermission;
+		}
+
+		// Otherwise, only check application permission
+		return hasApplicationPermission;
 	}
 
 }

--- a/src/main/java/ortus/boxlang/web/util/KeyDictionary.java
+++ b/src/main/java/ortus/boxlang/web/util/KeyDictionary.java
@@ -19,23 +19,26 @@ package ortus.boxlang.web.util;
 
 import ortus.boxlang.runtime.scopes.Key;
 
+/**
+ * A dictionary of keys used in BoxLang web applications.
+ * This class provides a centralized location for commonly used keys,
+ * making it easier to manage and reference them throughout the application.
+ */
 public class KeyDictionary {
 
+	// Global keys
 	public static final Key	bx_template_path	= Key.of( "bx_template_path" );
-	public static final Key	htmlHead			= Key.of( "htmlHead" );
-	public static final Key	htmlFooter			= Key.of( "htmlFooter" );
-	public static final Key	onRequestEnd		= Key.of( "onRequestEnd" );
-	public static final Key	fileName			= Key.of( "fileName" );
 	public static final Key	disposition			= Key.of( "disposition" );
+	public static final Key	fileName			= Key.of( "fileName" );
+	public static final Key	htmlFooter			= Key.of( "htmlFooter" );
+	public static final Key	htmlHead			= Key.of( "htmlHead" );
+	public static final Key	onRequestEnd		= Key.of( "onRequestEnd" );
 	public static final Key	success				= Key.of( "success" );
 
 	// File Upload keys
-	public static final Key	upload				= Key.of( "upload" );
-	public static final Key	uploadAll			= Key.of( "uploadAll" );
-	public static final Key	fileUpload			= Key.of( "fileUpload" );
-	public static final Key	fileUploadAll		= Key.of( "fileUploadAll" );
 	public static final Key	allowedExtensions	= Key.of( "allowedExtensions" );
 	public static final Key	attemptedServerFile	= Key.of( "attemptedServerFile" );
+	public static final Key	blockedExtensions	= Key.of( "blockedExtensions" );
 	public static final Key	clientDirectory		= Key.of( "clientDirectory" );
 	public static final Key	clientFile			= Key.of( "clientFile" );
 	public static final Key	clientFileExt		= Key.of( "clientFileExt" );
@@ -45,6 +48,8 @@ public class KeyDictionary {
 	public static final Key	dateLastAccessed	= Key.of( "dateLastAccessed" );
 	public static final Key	fileExisted			= Key.of( "fileExisted" );
 	public static final Key	fileSize			= Key.of( "fileSize" );
+	public static final Key	fileUpload			= Key.of( "fileUpload" );
+	public static final Key	fileUploadAll		= Key.of( "fileUploadAll" );
 	public static final Key	fileWasAppended		= Key.of( "fileWasAppended" );
 	public static final Key	fileWasOverwritten	= Key.of( "fileWasOverwritten" );
 	public static final Key	fileWasRenamed		= Key.of( "fileWasRenamed" );
@@ -56,14 +61,16 @@ public class KeyDictionary {
 	public static final Key	serverFileName		= Key.of( "serverFileName" );
 	public static final Key	timeCreated			= Key.of( "timeCreated" );
 	public static final Key	timeLastModified	= Key.of( "timeLastModified" );
+	public static final Key	upload				= Key.of( "upload" );
+	public static final Key	uploadAll			= Key.of( "uploadAll" );
 
 	// Session Cookie Settings
-	public static final Key	sessionCookie		= Key.of( "sessionCookie" );
-	public static final Key	secure				= Key.of( "secure" );
+	public static final Key	disableUpdate		= Key.of( "disableUpdate" );
+	public static final Key	encodevalue			= Key.of( "encodevalue" );
 	public static final Key	httpOnly			= Key.of( "httponly" );
 	public static final Key	sameSite			= Key.of( "sameSite" );
 	public static final Key	sameSiteMode		= Key.of( "sameSiteMode" );
-	public static final Key	disableUpdate		= Key.of( "disableUpdate" );
-	public static final Key	encodevalue			= Key.of( "encodevalue" );
+	public static final Key	secure				= Key.of( "secure" );
+	public static final Key	sessionCookie		= Key.of( "sessionCookie" );
 
 }

--- a/src/test/java/ortus/boxlang/web/bifs/FileUploadTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/FileUploadTest.java
@@ -1,4 +1,3 @@
-
 /**
  * [BoxLang]
  *
@@ -40,6 +39,8 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 
 import ortus.boxlang.runtime.dynamic.casters.StructCaster;
 import ortus.boxlang.runtime.scopes.Key;
@@ -50,6 +51,7 @@ import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
 import ortus.boxlang.runtime.util.FileSystemUtil;
 import ortus.boxlang.web.util.KeyDictionary;
 
+@Execution( ExecutionMode.SAME_THREAD )
 public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 
 	ArrayList<ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload>	mockUploads;
@@ -59,7 +61,6 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 	final String														testURLImage	= "https://ortus-public.s3.amazonaws.com/logos/ortus-medium.jpg";
 	final String														tmpDirectory	= "src/test/resources/tmp/FileUpload";
 	final String														testUpload		= tmpDirectory + "/test.jpg";
-
 	final String[]														testFields		= new String[] { "file1", "file2", "file3" };
 
 	@BeforeAll
@@ -96,7 +97,8 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 			} catch ( IOException e ) {
 				throw new BoxIOException( e );
 			}
-			mockUploads.add( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload( Key.of( field ), fieldFile, fieldFile.getFileName().toString() ) );
+			mockUploads.add( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload( Key.of( field ), fieldFile,
+			    fieldFile.getFileName().toString() ) );
 		} );
 
 		ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload[] uploadsArray = mockUploads
@@ -127,11 +129,19 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 
 		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isInstanceOf( String.class );
 		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isNotEmpty();
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).doesNotContain( "/" );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).doesNotContain( "\\" );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).endsWith( ".jpg" );
 		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
-		    .isEqualTo( Path.of( tmpDirectory, testFields[ 1 ] + ".jpg" ).toAbsolutePath().toString() );
+		    .isEqualTo( testFields[ 1 ] + ".jpg" );
 		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
 		    .isNotEqualTo( fileInfo.getAsString( KeyDictionary.serverFile ) );
 		assertThat( fileInfo.get( KeyDictionary.clientFileExt ) ).isEqualTo( "jpg" );
+		assertThat( fileInfo.get( KeyDictionary.clientFileName ) ).isEqualTo( testFields[ 1 ] );
+		assertThat( fileInfo.get( KeyDictionary.serverFileExt ) ).isEqualTo( "jpg" );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "." );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "/" );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "\\" );
 		assertThat( fileInfo.get( KeyDictionary.contentType ) ).isEqualTo( "image/jpeg" );
 		assertThat( fileInfo.get( KeyDictionary.contentSubType ) ).isEqualTo( "jpeg" );
 		assertThat( fileInfo.get( KeyDictionary.fileSize ) ).isEqualTo( fileInfo.get( KeyDictionary.oldFileSize ) );
@@ -157,11 +167,19 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 
 		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isInstanceOf( String.class );
 		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isNotEmpty();
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).doesNotContain( "/" );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).doesNotContain( "\\" );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).endsWith( ".jpg" );
 		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
-		    .isEqualTo( Path.of( tmpDirectory, testFields[ 0 ] + ".jpg" ).toAbsolutePath().toString() );
+		    .isEqualTo( testFields[ 0 ] + ".jpg" );
 		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
 		    .isNotEqualTo( fileInfo.getAsString( KeyDictionary.serverFile ) );
 		assertThat( fileInfo.get( KeyDictionary.clientFileExt ) ).isEqualTo( "jpg" );
+		assertThat( fileInfo.get( KeyDictionary.clientFileName ) ).isEqualTo( testFields[ 0 ] );
+		assertThat( fileInfo.get( KeyDictionary.serverFileExt ) ).isEqualTo( "jpg" );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "." );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "/" );
+		assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "\\" );
 		assertThat( fileInfo.get( KeyDictionary.contentType ) ).isEqualTo( "image/jpeg" );
 		assertThat( fileInfo.get( KeyDictionary.contentSubType ) ).isEqualTo( "jpeg" );
 		assertThat( fileInfo.get( KeyDictionary.fileSize ) ).isEqualTo( fileInfo.get( KeyDictionary.oldFileSize ) );
@@ -192,7 +210,7 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 		IStruct fileInfo = variables.getAsStruct( result );
 
 		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
-		    .isEqualTo( Path.of( tmpDirectory, testFields[ 0 ] + ".jpg" ).toAbsolutePath().toString() );
+		    .isEqualTo( testFields[ 0 ] + ".jpg" );
 		assertFalse( fileInfo.getAsBoolean( KeyDictionary.fileWasSaved ) );
 
 		// Test with strict mode on
@@ -206,8 +224,7 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 		    strict=true
 		            );
 		            """,
-		    context )
-		);
+		    context ) );
 
 		mockUploads.clear();
 		// Now test with a server defined disallow
@@ -218,7 +235,8 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 			} catch ( IOException e ) {
 				throw new BoxIOException( e );
 			}
-			mockUploads.add( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload( Key.of( field ), fieldFile, fieldFile.getFileName().toString() ) );
+			mockUploads.add( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload( Key.of( field ), fieldFile,
+			    fieldFile.getFileName().toString() ) );
 		} );
 
 		ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload[] uploadsArray = mockUploads
@@ -240,7 +258,8 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 		// );
 
 		// Now test server-level disallowed with strict off
-		// We have to change the file field because the error above will have deleted the disallowed file
+		// We have to change the file field because the error above will have deleted
+		// the disallowed file
 		variables.put( Key.of( "filefield" ), testFields[ 1 ] );
 		runtime.executeSource(
 		    """
@@ -257,7 +276,7 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
 		fileInfo = variables.getAsStruct( result );
 		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
-		    .isEqualTo( Path.of( tmpDirectory, testFields[ 1 ] + ".exe" ).toAbsolutePath().toString() );
+		    .isEqualTo( testFields[ 1 ] + ".exe" );
 		assertTrue( fileInfo.getAsBoolean( KeyDictionary.fileWasSaved ) );
 
 	}
@@ -281,14 +300,143 @@ public class FileUploadTest extends ortus.boxlang.web.util.BaseWebTest {
 		variables.getAsArray( result ).stream().map( StructCaster::cast ).forEach( fileInfo -> {
 			assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isInstanceOf( String.class );
 			assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isNotEmpty();
+			assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).doesNotContain( "/" );
+			assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).doesNotContain( "\\" );
+			assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).endsWith( ".jpg" );
 			assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
 			    .isNotEqualTo( fileInfo.getAsString( KeyDictionary.serverFile ) );
 			assertThat( fileInfo.get( KeyDictionary.clientFileExt ) ).isEqualTo( "jpg" );
+			assertThat( fileInfo.getAsString( KeyDictionary.clientFileName ) ).doesNotContain( "." );
+			assertThat( fileInfo.getAsString( KeyDictionary.clientFileName ) ).isAnyOf( testFields[ 0 ], testFields[ 1 ], testFields[ 2 ] );
+			assertThat( fileInfo.get( KeyDictionary.serverFileExt ) ).isEqualTo( "jpg" );
+			assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "." );
+			assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "/" );
+			assertThat( fileInfo.getAsString( KeyDictionary.serverFileName ) ).doesNotContain( "\\" );
 			assertThat( fileInfo.get( KeyDictionary.contentType ) ).isEqualTo( "image/jpeg" );
 			assertThat( fileInfo.get( KeyDictionary.contentSubType ) ).isEqualTo( "jpeg" );
 			assertThat( fileInfo.get( KeyDictionary.fileSize ) ).isEqualTo( fileInfo.get( KeyDictionary.oldFileSize ) );
 		} );
 
+	}
+
+	@DisplayName( "It tests the BIF FileUpload with blocked extensions" )
+	@Test
+	public void testBifFileUploadBlockedExtensions() {
+		// Reset uploads to ensure clean state
+		setupUploadsForTest();
+
+		variables.put( Key.of( "filefield" ), testFields[ 0 ] );
+		variables.put( Key.directory, Path.of( tmpDirectory ).toAbsolutePath().toString() );
+
+		// Test blocking jpg files with strict mode off
+		runtime.executeSource(
+		    """
+		            result = FileUpload(
+		            	filefield = filefield,
+		            	destination = directory,
+		          nameconflict = "makeunique",
+		       blockedExtensions = "jpg",
+		    strict=false
+		            );
+		            """,
+		    context );
+
+		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
+
+		IStruct fileInfo = variables.getAsStruct( result );
+
+		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
+		    .isEqualTo( testFields[ 0 ] + ".jpg" );
+		assertFalse( fileInfo.getAsBoolean( KeyDictionary.fileWasSaved ) );
+
+		// Reset uploads again for next test
+		setupUploadsForTest();
+
+		// Test blocking jpg files with strict mode on - should throw exception
+		assertThrows( BoxRuntimeException.class, () -> runtime.executeSource(
+		    """
+		            result = FileUpload(
+		            	filefield = filefield,
+		            	destination = directory,
+		          nameconflict = "makeunique",
+		       blockedExtensions = "jpg",
+		    strict=true
+		            );
+		            """,
+		    context ) );
+
+		// Reset uploads again for next test
+		setupUploadsForTest();
+
+		// Test blocking other extensions (not jpg) - should allow jpg upload
+		runtime.executeSource(
+		    """
+		            result = FileUpload(
+		            	filefield = filefield,
+		            	destination = directory,
+		          nameconflict = "makeunique",
+		       blockedExtensions = "exe,pdf,doc",
+		    strict=false
+		            );
+		            """,
+		    context );
+
+		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
+		fileInfo = variables.getAsStruct( result );
+		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
+		    .isEqualTo( testFields[ 0 ] + ".jpg" );
+		assertTrue( fileInfo.getAsBoolean( KeyDictionary.fileWasSaved ) );
+
+		// Reset uploads again for next test
+		setupUploadsForTest();
+
+		// Test combination of allowedExtensions and blockedExtensions
+		// Allow jpg and png, but block jpg - should result in no file saved
+		runtime.executeSource(
+		    """
+		            result = FileUpload(
+		            	filefield = filefield,
+		            	destination = directory,
+		          nameconflict = "makeunique",
+		       allowedExtensions = "jpg,png",
+		       blockedExtensions = "jpg",
+		    strict=false
+		            );
+		            """,
+		    context );
+
+		assertThat( variables.get( result ) ).isInstanceOf( IStruct.class );
+		fileInfo = variables.getAsStruct( result );
+		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
+		    .isEqualTo( testFields[ 0 ] + ".jpg" );
+		assertFalse( fileInfo.getAsBoolean( KeyDictionary.fileWasSaved ) );
+	}
+
+	/**
+	 * Helper method to setup clean uploads for each test scenario
+	 */
+	private void setupUploadsForTest() {
+		try {
+			mockUploads.clear();
+
+			Stream.of( testFields ).forEach( field -> {
+				Path fieldFile = Path.of( tmpDirectory, field + ".jpg" );
+				try {
+					Files.copy( Path.of( testUpload ), fieldFile, StandardCopyOption.REPLACE_EXISTING );
+				} catch ( IOException e ) {
+					throw new BoxIOException( e );
+				}
+				mockUploads.add( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload( Key.of( field ), fieldFile,
+				    fieldFile.getFileName().toString() ) );
+			} );
+
+			ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload[] uploadsArray = mockUploads
+			    .toArray( new ortus.boxlang.web.exchange.IBoxHTTPExchange.FileUpload[ 0 ] );
+
+			when( mockExchange.getUploadData() ).thenReturn( uploadsArray );
+		} catch ( Exception e ) {
+			throw new RuntimeException( "Failed to setup uploads for test", e );
+		}
 	}
 
 }

--- a/src/test/java/ortus/boxlang/web/components/FileTest.java
+++ b/src/test/java/ortus/boxlang/web/components/FileTest.java
@@ -39,7 +39,6 @@ public class FileTest extends ortus.boxlang.web.util.BaseWebTest {
 	String																testURLImage	= "https://ortus-public.s3.amazonaws.com/logos/ortus-medium.jpg";
 	String																tmpDirectory	= "src/test/resources/tmp/FileComponentTests";
 	String																testUpload		= tmpDirectory + "/test.jpg";
-
 	String[]															testFields		= new String[] { "file1", "file2", "file3" };
 
 	@BeforeAll
@@ -106,7 +105,7 @@ public class FileTest extends ortus.boxlang.web.util.BaseWebTest {
 		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isInstanceOf( String.class );
 		assertThat( fileInfo.getAsString( KeyDictionary.serverFile ) ).isNotEmpty();
 		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
-		    .isEqualTo( Path.of( tmpDirectory, testFields[ 0 ] + ".jpg" ).toAbsolutePath().toString() );
+		    .isEqualTo( testFields[ 0 ] + ".jpg" );
 		assertThat( fileInfo.getAsString( KeyDictionary.clientFile ) )
 		    .isNotEqualTo( fileInfo.getAsString( KeyDictionary.serverFile ) );
 		assertThat( fileInfo.get( KeyDictionary.clientFileExt ) ).isEqualTo( "jpg" );


### PR DESCRIPTION
# Release notes - BoxLang - 1.5.0

### Improvement

[BL-1556](https://ortussolutions.atlassian.net/browse/BL-1556) Bump org.semver4j:semver4j from 5.8.0 to 6.0.0.

[BL-1664](https://ortussolutions.atlassian.net/browse/BL-1664) fileUpload missing blockedExtensions argument

[BL-1680](https://ortussolutions.atlassian.net/browse/BL-1680) Better error if proxied UDF returns null where primitive is expected

[BL-1686](https://ortussolutions.atlassian.net/browse/BL-1686) add "output" key to Box Class Meta

[BL-1687](https://ortussolutions.atlassian.net/browse/BL-1687) Add \`Virtual\` Argument to BIF supporting parallel operations

[BL-1688](https://ortussolutions.atlassian.net/browse/BL-1688) DynamicObject not unwrapping arguments passed to method

[BL-1693](https://ortussolutions.atlassian.net/browse/BL-1693) Remove query column map from query metadata

[BL-1697](https://ortussolutions.atlassian.net/browse/BL-1697) Prevent memory leak with unbounded thread usage

[BL-1700](https://ortussolutions.atlassian.net/browse/BL-1700) Capture all generated keys

[BL-1701](https://ortussolutions.atlassian.net/browse/BL-1701) Capture update counts

[BL-1712](https://ortussolutions.atlassian.net/browse/BL-1712) AWS Runtime - Cache compiled lambda classes to avoid recompilations

[BL-1716](https://ortussolutions.atlassian.net/browse/BL-1716) AWS Runtime - Add aws runtime pool configuration via new ENV variable: BOXLANG\_LAMBDA\_CONNECTION\_POOL\_SIZE which defaults to 2

### Bug

[BL-1186](https://ortussolutions.atlassian.net/browse/BL-1186) queryExecute multiple statements

[BL-1660](https://ortussolutions.atlassian.net/browse/BL-1660) List BIFs which reassemble the list don't preserve delimiters

[BL-1661](https://ortussolutions.atlassian.net/browse/BL-1661) queryExecute - cannot execute query containing loose ':' and positional parameters

[BL-1663](https://ortussolutions.atlassian.net/browse/BL-1663) fileUpload: serverFileName, serverFile, clientFile, clientFileName are not correct per the spec

[BL-1667](https://ortussolutions.atlassian.net/browse/BL-1667) Interop service when dealing with methods with \`Object\` arguments, would give preference to coercionable arguments. Ex: Formatter.format\( BoxLang DateTime \) would fail

[BL-1668](https://ortussolutions.atlassian.net/browse/BL-1668) Trying to load module class before module is registered errors

[BL-1669](https://ortussolutions.atlassian.net/browse/BL-1669) duration can't compare against an integer

[BL-1670](https://ortussolutions.atlassian.net/browse/BL-1670) Compare operator cannot cast Duration to Number

[BL-1671](https://ortussolutions.atlassian.net/browse/BL-1671) JDBC - "driver not registered" log on engine startup despite being installed

[BL-1673](https://ortussolutions.atlassian.net/browse/BL-1673) Miniserver: Docker env var BOXLANG\_MODULES collides with modules key in config

[BL-1674](https://ortussolutions.atlassian.net/browse/BL-1674) super reference incorrect for mixin UDF in parent class

[BL-1675](https://ortussolutions.atlassian.net/browse/BL-1675) string caster not obeying fail flag when inputStream errors

[BL-1676](https://ortussolutions.atlassian.net/browse/BL-1676) HTTP Error When Accept-Encoding and TE Headers are being set as HTTP Params

[BL-1678](https://ortussolutions.atlassian.net/browse/BL-1678) Parsing error in QoQ with parentheses

[BL-1679](https://ortussolutions.atlassian.net/browse/BL-1679) Missing support for ACF script custom tags

[BL-1681](https://ortussolutions.atlassian.net/browse/BL-1681) Ignore extraneous return values from void proxies

[BL-1682](https://ortussolutions.atlassian.net/browse/BL-1682) Usage of quoted operators fails to compile. 

[BL-1683](https://ortussolutions.atlassian.net/browse/BL-1683) sqlPrettify is broken

[BL-1684](https://ortussolutions.atlassian.net/browse/BL-1684) CFML Compat - \`name\` annotation on Component overwrites the metadata name

[BL-1696](https://ortussolutions.atlassian.net/browse/BL-1696) Threads not always using context classloader

[BL-1699](https://ortussolutions.atlassian.net/browse/BL-1699) JDBC not handling raised errors

[BL-1705](https://ortussolutions.atlassian.net/browse/BL-1705) Module unload fails to remove/unregister module resources

[BL-1706](https://ortussolutions.atlassian.net/browse/BL-1706) Issues with numberFormat masks

[BL-1709](https://ortussolutions.atlassian.net/browse/BL-1709) Cache settings do not get replaced by environment variables

[BL-1715](https://ortussolutions.atlassian.net/browse/BL-1715) Java interop matching in correct overloaded methods

### New Feature

[BL-1127](https://ortussolutions.atlassian.net/browse/BL-1127) Add support for Lucee's encrypted datasource passwords in compat

[BL-1713](https://ortussolutions.atlassian.net/browse/BL-1713) AWS Runtime - Log performance metrics when in debug mode

[BL-1714](https://ortussolutions.atlassian.net/browse/BL-1714) AWS Runtime - URI Routing by convention using PascalCase: /products -> Products.bx, /home-savings -> HomeSavings.bx

[BL-1556]: https://ortussolutions.atlassian.net/browse/BL-1556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1664]: https://ortussolutions.atlassian.net/browse/BL-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1680]: https://ortussolutions.atlassian.net/browse/BL-1680?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1686]: https://ortussolutions.atlassian.net/browse/BL-1686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1687]: https://ortussolutions.atlassian.net/browse/BL-1687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1688]: https://ortussolutions.atlassian.net/browse/BL-1688?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1693]: https://ortussolutions.atlassian.net/browse/BL-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1697]: https://ortussolutions.atlassian.net/browse/BL-1697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BL-1700]: https://ortussolutions.atlassian.net/browse/BL-1700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ