### PR TITLE
Process `bx:cookie` `expires` values as dates before strings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
 	testImplementation "org.mockito:mockito-core:5.+"
 	testImplementation "com.google.truth:truth:1.+"
 	// Explicitly declare the JUnit platform launcher (to avoid deprecation)
-    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher:1.13.4"
 }
 
 java {

--- a/src/main/java/ortus/boxlang/web/components/Cookie.java
+++ b/src/main/java/ortus/boxlang/web/components/Cookie.java
@@ -146,22 +146,22 @@ public class Cookie extends Component {
 				// convert days to seconds
 				cookieInstance.setMaxAge( ( int ) ( numberAttempt.get().doubleValue() * 24 * 60 * 60 ) );
 			} else {
-				// Now try string
-				CastAttempt<String> stringAttempt = StringCasterStrict.attempt( expires );
-				if ( stringAttempt.wasSuccessful() ) {
-					String stringValue = stringAttempt.get();
-					if ( stringValue.equalsIgnoreCase( "now" ) ) {
-						cookieInstance.setMaxAge( 0 );
-					} else if ( stringValue.equalsIgnoreCase( "never" ) ) {
-						cookieInstance.setMaxAge( 60 * 60 * 24 * 365 * 30 ); // 30 years
-					} else {
-						throw new BoxValidationException( "Invalid cookie expiration string value: " + stringValue );
-					}
+				// now try date
+				CastAttempt<DateTime> dateAttempt = DateTimeCaster.attempt( expires );
+				if ( dateAttempt.wasSuccessful() ) {
+					cookieInstance.setExpires( dateAttempt.get().toDate() );
 				} else {
-					// finally try date
-					CastAttempt<DateTime> dateAttempt = DateTimeCaster.attempt( expires );
-					if ( dateAttempt.wasSuccessful() ) {
-						cookieInstance.setExpires( dateAttempt.get().toDate() );
+					// finally try string
+					CastAttempt<String> stringAttempt = StringCasterStrict.attempt( expires );
+					if ( stringAttempt.wasSuccessful() ) {
+						String stringValue = stringAttempt.get();
+						if ( stringValue.equalsIgnoreCase( "now" ) ) {
+							cookieInstance.setMaxAge( 0 );
+						} else if ( stringValue.equalsIgnoreCase( "never" ) ) {
+							cookieInstance.setMaxAge( 60 * 60 * 24 * 365 * 30 ); // 30 years
+						} else {
+							throw new BoxValidationException( "Invalid cookie expiration string value: " + stringValue );
+						}
 					} else {
 						throw new BoxValidationException( "Invalid cookie expiration type: " + expires.getClass().getName() );
 					}

--- a/src/test/java/ortus/boxlang/web/scopes/CookieScopeTest.java
+++ b/src/test/java/ortus/boxlang/web/scopes/CookieScopeTest.java
@@ -96,4 +96,24 @@ public class CookieScopeTest {
 		assertThat( variables.getAsString( Key.of( "checkCResult" ) ) ).isEqualTo( "baz" );
 	}
 
+	@DisplayName( "It can set a cookie expiration value with a date string" )
+	@Test
+	public void testSetCookieExpirationAsDateStringInComponent() {
+		// @formatter:off
+		instance.executeSource( """
+			cookieStruct = {
+				"name": "foo",
+				"value": "bar",
+				"expires": "Fri, 31 Dec 2038 23:59:59 GMT",
+			};
+			bx:cookie attributeCollection=cookieStruct;
+			check = cookie.keyExists( "foo" );
+			checkResult = cookie[ "foo" ];
+		""", context );
+		// @formatter:on
+		Object check = variables.get( Key.of( "check" ) );
+		assertThat( ( Boolean ) check ).isTrue();
+		assertThat( variables.getAsString( Key.of( "checkResult" ) ) ).isEqualTo( "bar" );
+	}
+
 }


### PR DESCRIPTION
# Description

Processing it as a string always succeeded, but would then fail as it only expected values like `now` or `never`.

## Jira/Github Issues

[BL-1758](https://ortussolutions.atlassian.net/browse/BL-1758)

## Type of change

Please delete options that are not relevant.

- [x] Bug Fix
- [ ] Improvement
- [ ] New Feature
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project [cfformat](../.cfformat.json) and [Java](../ortus-java-style.xml)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
