### PR TITLE
Add getHTTPResponseData BIF with tests

### DIFF
--- a/src/main/java/ortus/boxlang/web/bifs/GetHTTPResponseData.java
+++ b/src/main/java/ortus/boxlang/web/bifs/GetHTTPResponseData.java
@@ -1,0 +1,86 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+package ortus.boxlang.web.bifs;
+
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.runtime.types.Struct;
+import ortus.boxlang.web.context.WebRequestBoxContext;
+import ortus.boxlang.web.exchange.BoxCookie;
+import ortus.boxlang.web.exchange.IBoxHTTPExchange;
+
+@BoxBIF( description = "Retrieves HTTP response data such as status, headers, content type, and cookies." )
+public class GetHTTPResponseData extends BIF {
+
+	private static final String	DEFAULT_CONTENT_TYPE	= "text/html";
+
+	/**
+	 * Constructor
+	 */
+	public GetHTTPResponseData() {
+		super();
+	}
+
+	/**
+	 * Retrieves HTTP response data including status code, headers, content type, and cookies.
+	 *
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 *
+	 * @return A struct containing the HTTP response data.
+	 */
+	public Object _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		WebRequestBoxContext	requestContext	= context.getParentOfType( WebRequestBoxContext.class );
+		IBoxHTTPExchange		exchange		= requestContext.getHTTPExchange();
+
+		IStruct					headers			= new Struct( false );
+		exchange.getResponseHeaderMap().forEach( ( key, values ) -> {
+			if ( values != null && values.length > 0 ) {
+				headers.put( key, values[ 0 ] );
+			}
+		} );
+
+		IStruct cookies = new Struct( false );
+		for ( BoxCookie cookie : exchange.getResponseCookies() ) {
+			IStruct cookieStruct = Struct.ofNonConcurrent(
+			    Key.of( "name" ), cookie.getName(),
+			    Key.of( "value" ), cookie.getValue() != null ? cookie.getValue() : "",
+			    Key.of( "path" ), cookie.getPath() != null ? cookie.getPath() : "",
+			    Key.of( "domain" ), cookie.getDomain() != null ? cookie.getDomain() : "",
+			    Key.of( "maxAge" ), cookie.getMaxAge() != null ? cookie.getMaxAge() : -1,
+			    Key.of( "expires" ), cookie.getExpires(),
+			    Key.of( "secure" ), cookie.isSecure(),
+			    Key.of( "httpOnly" ), cookie.isHttpOnly(),
+			    Key.of( "sameSite" ), cookie.isSameSite(),
+			    Key.of( "sameSiteMode" ), cookie.getSameSiteMode() != null ? cookie.getSameSiteMode() : ""
+			);
+			cookies.put( cookie.getName(), cookieStruct );
+		}
+
+		String contentType = exchange.getResponseHeader( "Content-Type" );
+
+		return Struct.ofNonConcurrent(
+		    Key.of( "status" ), exchange.getResponseStatus(),
+		    Key.of( "contentType" ), contentType != null ? contentType : DEFAULT_CONTENT_TYPE,
+		    Key.of( "headers" ), headers,
+		    Key.of( "cookies" ), cookies
+		);
+	}
+
+}

--- a/src/main/java/ortus/boxlang/web/exchange/IBoxHTTPExchange.java
+++ b/src/main/java/ortus/boxlang/web/exchange/IBoxHTTPExchange.java
@@ -358,6 +358,13 @@ public interface IBoxHTTPExchange {
 	public boolean isResponseStarted();
 
 	/**
+	 * Returns the cookies that have been added to the response, or an empty array if none.
+	 */
+	default BoxCookie[] getResponseCookies() {
+		return new BoxCookie[ 0 ];
+	}
+
+	/**
 	 * Adds the specified cookie to the response. This method can be called multiple times to set more than one cookie.
 	 *
 	 */

--- a/src/test/java/ortus/boxlang/web/bifs/GetHTTPResponseDataTest.java
+++ b/src/test/java/ortus/boxlang/web/bifs/GetHTTPResponseDataTest.java
@@ -1,0 +1,141 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2023] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.web.bifs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.runtime.scopes.Key;
+import ortus.boxlang.runtime.types.IStruct;
+import ortus.boxlang.web.exchange.BoxCookie;
+import ortus.boxlang.web.util.BaseWebTest;
+
+public class GetHTTPResponseDataTest extends BaseWebTest {
+
+	@Test
+	@DisplayName( "It returns default values when no response data has been set" )
+	public void testDefaultValues() {
+		runtime.executeSource( "result = getHTTPResponseData();", context );
+
+		IStruct data = ( IStruct ) variables.get( result );
+
+		assertThat( data ).isNotNull();
+		assertThat( data.get( Key.of( "status" ) ) ).isEqualTo( 200 );
+		assertThat( data.getAsString( Key.of( "contentType" ) ) ).isEqualTo( "text/html" );
+		assertThat( data.get( Key.of( "headers" ) ) ).isInstanceOf( IStruct.class );
+		assertThat( data.get( Key.of( "cookies" ) ) ).isInstanceOf( IStruct.class );
+	}
+
+	@Test
+	@DisplayName( "It returns the current response status code" )
+	public void testWithStatus() {
+		mockExchange.setResponseStatus( 404 );
+
+		runtime.executeSource( "result = getHTTPResponseData();", context );
+
+		IStruct data = ( IStruct ) variables.get( result );
+		assertThat( data.get( Key.of( "status" ) ) ).isEqualTo( 404 );
+	}
+
+	@Test
+	@DisplayName( "It returns the Content-Type header as contentType" )
+	public void testWithContentType() {
+		mockExchange.setResponseHeader( "Content-Type", "application/json" );
+
+		runtime.executeSource( "result = getHTTPResponseData();", context );
+
+		IStruct data = ( IStruct ) variables.get( result );
+		assertThat( data.getAsString( Key.of( "contentType" ) ) ).isEqualTo( "application/json" );
+	}
+
+	@Test
+	@DisplayName( "It returns response headers in the headers struct" )
+	public void testWithResponseHeaders() {
+		mockExchange.setResponseHeader( "X-Custom-Header", "myValue" );
+		mockExchange.setResponseHeader( "Cache-Control", "no-cache" );
+
+		runtime.executeSource( "result = getHTTPResponseData();", context );
+
+		IStruct data	= ( IStruct ) variables.get( result );
+		IStruct headers	= ( IStruct ) data.get( Key.of( "headers" ) );
+
+		assertThat( headers ).isNotNull();
+		assertThat( headers.getAsString( Key.of( "X-Custom-Header" ) ) ).isEqualTo( "myValue" );
+		assertThat( headers.getAsString( Key.of( "Cache-Control" ) ) ).isEqualTo( "no-cache" );
+	}
+
+	@Test
+	@DisplayName( "It returns response cookies in the cookies struct" )
+	public void testWithResponseCookies() {
+		BoxCookie cookie = new BoxCookie( "sessionId", "abc123" );
+		cookie.setPath( "/" );
+		cookie.setHttpOnly( true );
+		cookie.setSecure( true );
+		mockExchange.addResponseCookie( cookie );
+
+		runtime.executeSource( "result = getHTTPResponseData();", context );
+
+		IStruct data	= ( IStruct ) variables.get( result );
+		IStruct cookies	= ( IStruct ) data.get( Key.of( "cookies" ) );
+
+		assertThat( cookies ).isNotNull();
+		assertThat( cookies.containsKey( Key.of( "sessionId" ) ) ).isTrue();
+
+		IStruct cookieData = ( IStruct ) cookies.get( Key.of( "sessionId" ) );
+		assertThat( cookieData.getAsString( Key.of( "name" ) ) ).isEqualTo( "sessionId" );
+		assertThat( cookieData.getAsString( Key.of( "value" ) ) ).isEqualTo( "abc123" );
+		assertThat( cookieData.getAsString( Key.of( "path" ) ) ).isEqualTo( "/" );
+		assertThat( cookieData.get( Key.of( "httpOnly" ) ) ).isEqualTo( true );
+		assertThat( cookieData.get( Key.of( "secure" ) ) ).isEqualTo( true );
+	}
+
+	@Test
+	@DisplayName( "It returns multiple response cookies" )
+	public void testWithMultipleCookies() {
+		mockExchange.addResponseCookie( new BoxCookie( "cookieA", "valueA" ) );
+		mockExchange.addResponseCookie( new BoxCookie( "cookieB", "valueB" ) );
+
+		runtime.executeSource( "result = getHTTPResponseData();", context );
+
+		IStruct data	= ( IStruct ) variables.get( result );
+		IStruct cookies	= ( IStruct ) data.get( Key.of( "cookies" ) );
+
+		assertThat( cookies.size() ).isEqualTo( 2 );
+		assertThat( cookies.containsKey( Key.of( "cookieA" ) ) ).isTrue();
+		assertThat( cookies.containsKey( Key.of( "cookieB" ) ) ).isTrue();
+	}
+
+	@Test
+	@DisplayName( "It returns empty structs by default for headers and cookies" )
+	public void testHeadersAndCookiesDefaultToEmptyStructs() {
+		runtime.executeSource( "result = getHTTPResponseData();", context );
+
+		IStruct data = ( IStruct ) variables.get( result );
+
+		IStruct headers	= ( IStruct ) data.get( Key.of( "headers" ) );
+		IStruct cookies	= ( IStruct ) data.get( Key.of( "cookies" ) );
+
+		assertThat( headers ).isNotNull();
+		assertThat( cookies ).isNotNull();
+		assertThat( headers.size() ).isEqualTo( 0 );
+		assertThat( cookies.size() ).isEqualTo( 0 );
+	}
+
+}


### PR DESCRIPTION
Returns a snapshot of the current HTTP response state — status code,
contentType (defaulting to text/html), response headers struct, and
a cookies struct keyed by name (each entry is a struct of cookie
properties). Adds getResponseCookies() as a default method on
IBoxHTTPExchange so implementations that don't override it safely
return an empty array.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013LqYSxjw97ZE28vGyyvG4Q